### PR TITLE
TRAC-738: referrer issue, TRAC-1137: pur events

### DIFF
--- a/extensions/cmp_interaction_tracking.js
+++ b/extensions/cmp_interaction_tracking.js
@@ -54,7 +54,8 @@
         onMessageChoiceSelect,
         onPrivacyManagerAction,
         onCmpuishown,
-        initABTestingProperties
+        initABTestingProperties,
+        sendLinkEvent
     };
 
     function getABTestingProperties() {
@@ -78,6 +79,15 @@
 
     function onMessageReceiveData(data) {
         setABTestingProperties(data);
+    }
+
+    function sendLinkEvent(label) {
+        window.utag.link({
+            'event_name': 'cmp_interactions',
+            'event_action': 'click',
+            'event_label': label,
+            'event_data': getABTestingProperties()
+        });
     }
 
     function onMessageChoiceSelect(id, eventType) {

--- a/extensions/cmp_interaction_tracking.js
+++ b/extensions/cmp_interaction_tracking.js
@@ -120,7 +120,7 @@
             setTimeout(() => {
                 exportedFunctions.sendLinkEvent(TCFAPI_COMMON_EVENTS.CMP_UI_SHOWN);
                 window.utag.data['cmp_interactions_true'] = 'false';
-            }, 3000);
+            }, 500);
         }
     }
 

--- a/extensions/cmp_interaction_tracking.js
+++ b/extensions/cmp_interaction_tracking.js
@@ -94,13 +94,7 @@
         if (CONSENT_MESSAGE_EVENTS[eventType]) {
             window.utag.data['cmp_events'] = CONSENT_MESSAGE_EVENTS[eventType];
             window.utag.data['cmp_interactions_true'] = 'true';
-            window.utag.link({
-                'event_name': 'cmp_interactions',
-                'event_action': 'click',
-                'event_label': CONSENT_MESSAGE_EVENTS[eventType],
-                'event_data': getABTestingProperties()
-            }, function () {
-            });
+            exportedFunctions.sendLinkEvent(CONSENT_MESSAGE_EVENTS[eventType]);
             window.utag.data['cmp_interactions_true'] = 'false';
         }
     }
@@ -109,13 +103,7 @@
         if (PRIVACY_MANAGER_EVENTS[eventType] || eventType.purposeConsent) {
             window.utag.data['cmp_events'] = eventType.purposeConsent ? (eventType.purposeConsent === 'all' ? PRIVACY_MANAGER_EVENTS.ACCEPT_ALL : PRIVACY_MANAGER_EVENTS.SAVE_AND_EXIT) : PRIVACY_MANAGER_EVENTS[eventType];
             window.utag.data['cmp_interactions_true'] = 'true';
-            window.utag.link({
-                'event_name': 'cmp_interactions',
-                'event_action': 'click',
-                'event_label': window.utag.data['cmp_events'],
-                'event_data': getABTestingProperties()
-            }, function () {
-            });
+            exportedFunctions.sendLinkEvent(window.utag.data['cmp_events']);
             window.utag.data['cmp_interactions_true'] = 'false';
         }
     }
@@ -123,20 +111,17 @@
     function onCmpuishown(tcData) {
         if (tcData && tcData.eventStatus === 'cmpuishown') {
             window.utag.data.cmp_events = 'cm_layer_shown';
-            setTimeout(function () {
+
+            setTimeout(()=>{
                 window.utag.data['cmp_events'] = TCFAPI_COMMON_EVENTS.CMP_UI_SHOWN;
                 window.utag.data['cmp_interactions_true'] = 'true';
                 window.utag.data['first_pv'] = 'true';
-                window.utag.view(window.utag.data, function () {
-                    window.utag.link({
-                        'event_name': 'cmp_interactions',
-                        'event_action': 'click',
-                        'event_label': TCFAPI_COMMON_EVENTS.CMP_UI_SHOWN,
-                        'event_data': getABTestingProperties()
-                    }, function () {
-                    });
-                }, [adobeTagId]);
-            }, 300); //fixme: decide for a proper timeout value
+                window.utag.view(window.utag.data, null, [adobeTagId]);
+            }, 300);
+
+            setTimeout(() => {
+                exportedFunctions.sendLinkEvent(TCFAPI_COMMON_EVENTS.CMP_UI_SHOWN);
+            }, 800);
             window.utag.data['cmp_interactions_true'] = 'false';
         }
     }

--- a/extensions/cmp_interaction_tracking.js
+++ b/extensions/cmp_interaction_tracking.js
@@ -120,7 +120,7 @@
             setTimeout(() => {
                 exportedFunctions.sendLinkEvent(TCFAPI_COMMON_EVENTS.CMP_UI_SHOWN);
                 window.utag.data['cmp_interactions_true'] = 'false';
-            }, 500);
+            }, 3000);
         }
     }
 

--- a/tests/cmp_interaction_tracking.test.js
+++ b/tests/cmp_interaction_tracking.test.js
@@ -191,6 +191,21 @@ describe('CMP Interaction Tracking', () => {
         });
     });
 
+    describe('sendLinkEvent()', () => {
+        it('should call utag.link function with correct arguments', () => {
+            const anyLabel = 'any-label';
+            setABTestingProperties();
+            cmpInteractionTracking.sendLinkEvent(anyLabel);
+            expect(window.utag.link).toHaveBeenCalledWith(
+                {
+                    'event_name': 'cmp_interactions',
+                    'event_action': 'click',
+                    'event_label': anyLabel,
+                    'event_data': `${ABTestingProperties.messageId} ${ABTestingProperties.msgDescription} ${ABTestingProperties.bucket}`
+                });
+        });
+    });
+
     describe('onMessageChoiceSelect(id, eventType)', () => {
         it('should set correct utag.data properties when eventType === 11', () => {
             cmpInteractionTracking.onMessageChoiceSelect('any-id', 11);

--- a/tests/cmp_interaction_tracking.test.js
+++ b/tests/cmp_interaction_tracking.test.js
@@ -383,7 +383,6 @@ describe('CMP Interaction Tracking', () => {
 
         it('should call utag.view with correct values', () => {
             cmpInteractionTracking.onCmpuishown({eventStatus: 'cmpuishown'});
-            jest.runAllTimers();
             expect(window.utag.view).toHaveBeenNthCalledWith(1,
                 {
                     'cmp_events': 'cm_layer_shown',
@@ -417,6 +416,25 @@ describe('CMP Interaction Tracking', () => {
                     'event_label': 'cm_layer_shown',
                     'event_data': `${ABTestingProperties.messageId} ${ABTestingProperties.msgDescription} ${ABTestingProperties.bucket}`
                 });
+        });
+    });
+
+    describe('onMessage', () => {
+        it('should call utag.link function with correct parameters', function () {
+            const label = 'any-label';
+            setABTestingProperties();
+            cmpInteractionTracking.onMessage({
+                data: {
+                    cmpLayerMessage: true,
+                    payload: label
+                },
+            });
+            expect(window.utag.link).toHaveBeenCalledWith({
+                'event_name': 'cmp_interactions',
+                'event_action': 'click',
+                'event_label': label,
+                'event_data': `${ABTestingProperties.messageId} ${ABTestingProperties.msgDescription} ${ABTestingProperties.bucket}`
+            });
         });
     });
 

--- a/tests/cmp_interaction_tracking.test.js
+++ b/tests/cmp_interaction_tracking.test.js
@@ -38,6 +38,7 @@ function setABTestingProperties() {
 function createWindowMock() {
     return {
         localStorage: browserMocks.localStorageMock,
+        addEventListener: jest.fn(),
         _sp_: {
             addEventListener: jest.fn(),
             config: 'any-config'
@@ -160,6 +161,7 @@ describe('CMP Interaction Tracking', () => {
             expect(window._sp_.addEventListener).toHaveBeenCalledWith('onMessageChoiceSelect', cmpInteractionTracking.onMessageChoiceSelect);
             expect(window._sp_.addEventListener).toHaveBeenCalledWith('onPrivacyManagerAction', cmpInteractionTracking.onPrivacyManagerAction);
             expect(window.__tcfapi).toHaveBeenCalledWith('addEventListener', 2, cmpInteractionTracking.onCmpuishown);
+            expect(window.addEventListener).toHaveBeenCalledWith('message', cmpInteractionTracking.onMessage, false);
         });
     });
 
@@ -407,8 +409,6 @@ describe('CMP Interaction Tracking', () => {
             setABTestingProperties();
             cmpInteractionTracking.onCmpuishown({eventStatus: 'cmpuishown'});
             jest.runAllTimers();
-            const utagViewCallback = window.utag.view.mock.calls[0][1];
-            utagViewCallback();
             expect(window.utag.link).toHaveBeenNthCalledWith(1,
                 {
                     'event_name': 'cmp_interactions',

--- a/tests/cmp_interaction_tracking.test.js
+++ b/tests/cmp_interaction_tracking.test.js
@@ -224,7 +224,7 @@ describe('CMP Interaction Tracking', () => {
                     'event_action': 'click',
                     'event_label': 'cm_accept_all',
                     'event_data': `${ABTestingProperties.messageId} ${ABTestingProperties.msgDescription} ${ABTestingProperties.bucket}`
-                }, expect.any(Function));
+                });
         });
 
         it('should set correct utag.data properties when eventType === 12', () => {
@@ -244,7 +244,7 @@ describe('CMP Interaction Tracking', () => {
                     'event_action': 'click',
                     'event_label': 'cm_show_privacy_manager',
                     'event_data': `${ABTestingProperties.messageId} ${ABTestingProperties.msgDescription} ${ABTestingProperties.bucket}`
-                }, expect.any(Function));
+                });
         });
 
         it('should set correct utag.data properties when eventType === 13', () => {
@@ -264,7 +264,7 @@ describe('CMP Interaction Tracking', () => {
                     'event_action': 'click',
                     'event_label': 'cm_reject_all',
                     'event_data': `${ABTestingProperties.messageId} ${ABTestingProperties.msgDescription} ${ABTestingProperties.bucket}`
-                }, expect.any(Function));
+                });
         });
 
         it('should NOT call utag.link when called with wrong event type', () => {
@@ -293,7 +293,7 @@ describe('CMP Interaction Tracking', () => {
                     'event_action': 'click',
                     'event_label': 'pm_save_and_exit',
                     'event_data': `${ABTestingProperties.messageId} ${ABTestingProperties.msgDescription} ${ABTestingProperties.bucket}`
-                }, expect.any(Function));
+                });
         });
 
         it('should set correct utag.data properties when eventType === ACCEPT_ALL', () => {
@@ -314,7 +314,7 @@ describe('CMP Interaction Tracking', () => {
                     'event_action': 'click',
                     'event_label': 'pm_accept_all',
                     'event_data': `${ABTestingProperties.messageId} ${ABTestingProperties.msgDescription} ${ABTestingProperties.bucket}`
-                }, expect.any(Function));
+                });
         });
 
         it('should set utag.data properties when called with an all purposeConsent', () => {
@@ -334,7 +334,7 @@ describe('CMP Interaction Tracking', () => {
                     'event_action': 'click',
                     'event_label': 'pm_accept_all',
                     'event_data': `${ABTestingProperties.messageId} ${ABTestingProperties.msgDescription} ${ABTestingProperties.bucket}`
-                }, expect.any(Function));
+                });
         });
 
         it('should set utag.data properties when called with a purposeConsent other from all', () => {
@@ -354,7 +354,7 @@ describe('CMP Interaction Tracking', () => {
                     'event_action': 'click',
                     'event_label': 'pm_save_and_exit',
                     'event_data': `${ABTestingProperties.messageId} ${ABTestingProperties.msgDescription} ${ABTestingProperties.bucket}`
-                }, expect.any(Function));
+                });
         });
 
         it('should NOT call utag.link when called with wrong eventType', () => {
@@ -373,10 +373,11 @@ describe('CMP Interaction Tracking', () => {
 
         it('should set correct utag.data properties', () => {
             cmpInteractionTracking.onCmpuishown({eventStatus: 'cmpuishown'});
-
+            jest.runAllTimers();
             expect(window.utag.data).toEqual({
                 'cmp_events': 'cm_layer_shown',
-                'cmp_interactions_true': 'false'
+                'cmp_interactions_true': 'false',
+                'first_pv': 'true'
             });
         });
 
@@ -388,7 +389,7 @@ describe('CMP Interaction Tracking', () => {
                     'cmp_events': 'cm_layer_shown',
                     'cmp_interactions_true': 'true',
                     'first_pv': 'true'
-                }, expect.any(Function), [undefined]);
+                }, null, [undefined]);
         });
 
         it('should NOT call utag.view when called without event status', () => {
@@ -415,7 +416,7 @@ describe('CMP Interaction Tracking', () => {
                     'event_action': 'click',
                     'event_label': 'cm_layer_shown',
                     'event_data': `${ABTestingProperties.messageId} ${ABTestingProperties.msgDescription} ${ABTestingProperties.bucket}`
-                }, expect.any(Function));
+                });
         });
     });
 


### PR DESCRIPTION
https://as-jira.axelspringer.de/browse/TRAC-738
https://as-jira.axelspringer.de/browse/TRAC-1137

- adding small delay between utag.view and utag.link call in onCmpuishown() handler (TRAC-738)
- adding new event handler onMessage() for handling PUR events (TRAC-1137)
- refactoring: moving utag.link calls to separate sendLinkEvent() function
- update tests

We should do some testing on DEV/QA before merging this PR!