### PR TITLE
Get global adobe object

### DIFF
--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -1,5 +1,19 @@
+function _getAdobeObject() {
+    let adobeObject = {};
+
+    // Check existence of Adobe object by looking for certain properties.
+    if (window.s && window.s.account && window.s.version) {
+        adobeObject = window.s;
+    // is Adobe object named 'cmp'
+    } else if (window.cmp && window.cmp.account && window.cmp.version) {
+        adobeObject = window.cmp;
+    }
+    return adobeObject;
+}
+
 /* eslint-disable */
-const s = window.s || window.cmp || {};
+const s = _getAdobeObject();
+
 
 // START: Pre-defined Adobe Plugins
 /* istanbul ignore next */
@@ -29,6 +43,7 @@ s.split = new Function("l","d",""
  * Utility functions which get used by various features.
  */
 s._utils = {
+    getAdobeObject: _getAdobeObject,
     getDomainFromURLString: function (urlString) {
         try {
             const urlObject = new URL(urlString);
@@ -575,7 +590,6 @@ s._plusDensityObj = {
  */
 s._init = function (s) {
     s.currencyCode = 'EUR';
-    s.execdoplugins = 0;
     s.expectSupplementalData = false;
     s.myChannels = 0;
     s.usePlugins = true;

--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -1,10 +1,9 @@
 function _getAdobeObject() {
     let adobeObject = {};
 
-    // Check existence of Adobe object by looking for certain properties.
+    // Check if global variables contain the Adobe object or something else.
     if (window.s && window.s.account && window.s.version) {
         adobeObject = window.s;
-    // is Adobe object named 'cmp'
     } else if (window.cmp && window.cmp.account && window.cmp.version) {
         adobeObject = window.cmp;
     }

--- a/tests/doplugins/doplugins_init.test.js
+++ b/tests/doplugins/doplugins_init.test.js
@@ -36,7 +36,6 @@ describe('init()', () => {
         s._init(s);
 
         expect(s.currencyCode).toBe('EUR');
-        expect(s.execdoplugins).toBe(0);
         expect(s.expectSupplementalData).toBe(false);
         expect(s.myChannels).toBe(0);
         expect(s.usePlugins).toBe(true);

--- a/tests/doplugins/doplugins_utils.test.js
+++ b/tests/doplugins/doplugins_utils.test.js
@@ -17,6 +17,48 @@ describe('s_utils', () => {
         jest.restoreAllMocks();
     });
 
+    describe('getAdobeObject', () => {
+        const validAdobeObject = {
+            account: 'any-account',
+            version: 'any-version'
+        };
+
+        const invalidAdobeObject = {
+            account: 'any-account'
+        };
+
+        it('should return the Adobe object when it has the name \'s\'', () => {
+            window.s = validAdobeObject;
+            const result = s._utils.getAdobeObject();
+            expect(result).toBe(validAdobeObject);
+        });
+
+        it('should return an empty object when something else is assigned to the global variable with name \'s\'', () => {
+            window.s = invalidAdobeObject;
+            const result = s._utils.getAdobeObject();
+            expect(result).toEqual({});
+        });
+
+        it('should return the Adobe object when it has the name \'cmp\'', () => {
+            window.cmp = validAdobeObject;
+            const result = s._utils.getAdobeObject();
+            expect(result).toBe(validAdobeObject);
+        });
+
+        it('should return an empty object when something else is assigned to the global variable with name \'cmp\'', () => {
+            window.cmp = invalidAdobeObject;
+            const result = s._utils.getAdobeObject();
+            expect(result).toEqual({});
+        });
+
+        it('should return an empty object when something else is assigned to the global variables \'s\' and \'cmp\' ', () => {
+            window.s = invalidAdobeObject;
+            window.cmp = invalidAdobeObject;
+            const result = s._utils.getAdobeObject();
+            expect(result).toEqual({});
+        });
+    });
+
     describe('getDomainFromURLString(URLString)', () => {
         it('should return domain from URL string', () => {
             const domain = 'www.bild.de';


### PR DESCRIPTION
- add utility function for finding the Adobe S-Object (and not something else)
- removing unused property: s.execdoplugins