### PR TITLE
Trac 1217: cmp first pv

### DIFF
--- a/extensions/cmp_interaction_tracking.js
+++ b/extensions/cmp_interaction_tracking.js
@@ -13,6 +13,31 @@
         CMP_UI_SHOWN: 'cm_layer_shown',
     };
 
+    // Tealium profile to Adobe TagId mapping.
+    const TEALIUM_PROFILES = {
+        'abo-autobild.de': 23,
+        'ac-autobild': 10,
+        'ac-computerbild': 9,
+        'ac-wieistmeineip': 4,
+        'asmb-metal-hammer.de': 22,
+        'asmb-musikexpress.de': 14,
+        'asmb-rollingstone.de': 16,
+        'bild-bild.de': 12,
+        'bild-fitbook.de': 40,
+        'bild-myhomebook.de': 37,
+        'bild-sportbild.de': 16,
+        'bild-stylebook.de': 30,
+        'bild-techbook.de': 82,
+        'bild-travelbook.de': 42,
+        'bild-offer': 24,
+        'bild': 386,
+        'bz-bz-berlin.de': 9,
+        'cbo-computerbild.de': 25,
+        'shop.bild': 181,
+        'welt': 233,
+        'welt-shop.welt.de': 28
+    };
+
     let cmp_ab_id = '';
     let cmp_ab_desc = '';
     let cmp_ab_bucket = '';
@@ -22,6 +47,7 @@
         init,
         run,
         configSourcepoint,
+        getAdobeTagId,
         registerEventHandler,
         onMessageReceiveData,
         onMessageChoiceSelect,
@@ -108,15 +134,27 @@
 
     function onCmpuishown(tcData) {
         if (tcData && tcData.eventStatus === 'cmpuishown') {
+            const adobeTagId = exportedFunctions.getAdobeTagId(window.utag.data['ut.profile']);
             window.utag.data.cmp_events = TCFAPI_COMMON_EVENTS.CMP_UI_SHOWN;
-            exportedFunctions.sendLinkEvent(TCFAPI_COMMON_EVENTS.CMP_UI_SHOWN);
-        }
+            window.utag.view(window.utag.data, null, [adobeTagId]);
+            // Ensure that view event gets processed before link event by adding a delay.
+            setTimeout(() => {
+                exportedFunctions.sendLinkEvent(TCFAPI_COMMON_EVENTS.CMP_UI_SHOWN);
+            }, 500);        }
     }
 
     function onMessage(event) {
         if (event.data && event.data.cmpLayerMessage) {
             exportedFunctions.sendLinkEvent(event.data.payload);
         }
+    }
+
+    function getAdobeTagId(tealiumProfileName) {
+        const adobeTagId = TEALIUM_PROFILES[tealiumProfileName];
+        if (!adobeTagId) {
+            throw new Error('Cannot find Adobe Tag ID for profile: ' + tealiumProfileName);
+        }
+        return adobeTagId;
     }
 
     function registerEventHandler() {

--- a/extensions/cmp_interaction_tracking.js
+++ b/extensions/cmp_interaction_tracking.js
@@ -96,7 +96,8 @@
 
     function isAfterCMP() {
         const hasCMPAfterCookie = window.utag.data['cp.utag_main_cmp_after'] ? (window.utag.data['cp.utag_main_cmp_after'].toLowerCase() === 'true') : false;
-        const hasVendorList = !!window.utag.data.consentedVendors;
+        const defaultVendorList = 'adobe_cmp';
+        const hasVendorList = !!window.utag.data.consentedVendors && window.utag.data.consentedVendors !== defaultVendorList;
 
         return hasCMPAfterCookie || hasVendorList;
     }

--- a/extensions/cmp_interaction_tracking.js
+++ b/extensions/cmp_interaction_tracking.js
@@ -95,8 +95,8 @@
 
     function hasUserDeclinedConsent() {
         return window.utag.data['cp.utag_main_cmp_after']
-            && window.utag.data.consentedVendors
-            && !window.utag.data.consentedVendors.includes('adobe_analytics');
+            && (!window.utag.data.consentedVendors ||
+                window.utag.data.consentedVendors && !window.utag.data.consentedVendors.includes('adobe_analytics'));
     }
 
     function sendLinkEvent(label) {

--- a/extensions/cmp_interaction_tracking.js
+++ b/extensions/cmp_interaction_tracking.js
@@ -132,6 +132,7 @@
 
             if (eventType === 11 || eventType === 13) {
                 window.utag.loader.SC('utag_main', {'cmp_after': 'true' + ';exp-session'});
+                window.utag.data['cp.utag_main_cmp_after'] = true;
             }
 
             if (eventType === 11) {
@@ -146,6 +147,7 @@
             exportedFunctions.sendLinkEvent(window.utag.data['cmp_events']);
             // Set cookie for first page view tracking.
             window.utag.loader.SC('utag_main', {'cmp_after': 'true' + ';exp-session'});
+            window.utag.data['cp.utag_main_cmp_after'] = true;
         }
     }
 

--- a/extensions/cmp_interaction_tracking.js
+++ b/extensions/cmp_interaction_tracking.js
@@ -95,7 +95,10 @@
     }
 
     function isAfterCMP() {
-        return window.utag.data['cp.utag_main_cmp_after'] ? (window.utag.data['cp.utag_main_cmp_after'].toLowerCase() === 'true') : false;
+        const hasCMPAfterCookie = window.utag.data['cp.utag_main_cmp_after'] ? (window.utag.data['cp.utag_main_cmp_after'].toLowerCase() === 'true') : false;
+        const hasVendorList = !!window.utag.data.consentedVendors;
+
+        return hasCMPAfterCookie || hasVendorList;
     }
 
     function hasUserDeclinedConsent() {

--- a/extensions/cmp_interaction_tracking.js
+++ b/extensions/cmp_interaction_tracking.js
@@ -96,10 +96,10 @@
 
     function isAfterCMP() {
         const hasCMPAfterCookie = window.utag.data['cp.utag_main_cmp_after'] ? (window.utag.data['cp.utag_main_cmp_after'].toLowerCase() === 'true') : false;
-        const defaultVendorList = 'adobe_cmp';
-        const hasVendorList = !!window.utag.data.consentedVendors && window.utag.data.consentedVendors !== defaultVendorList;
+        const defaultVendors = 'adobe_cmp';
+        const hasVendors = !!window.utag.data.consentedVendors && window.utag.data.consentedVendors !== defaultVendors;
 
-        return hasCMPAfterCookie || hasVendorList;
+        return hasCMPAfterCookie || hasVendors;
     }
 
     function hasUserDeclinedConsent() {

--- a/extensions/cmp_interaction_tracking.js
+++ b/extensions/cmp_interaction_tracking.js
@@ -58,7 +58,8 @@
         onMessage,
         setABTestingProperties,
         getABTestingProperties,
-        onUserConsent
+        onUserConsent,
+        sendFirstPageViewEvent
     };
 
     function getABTestingProperties() {
@@ -107,6 +108,14 @@
         }
     }
 
+    function sendFirstPageViewEvent() {
+        // Check if user has already given/declined consent
+        if (!window.utag.data['cp.utag_main_cmp_after']) {
+            const adobeTagId = exportedFunctions.getAdobeTagId(window.utag.data['ut.profile']);
+            window.utag.view(window.utag.data, null, [adobeTagId]);
+        }
+    }
+
     function onMessageChoiceSelect(id, eventType) {
         if (CONSENT_MESSAGE_EVENTS[eventType]) {
             window.utag.data['cmp_events'] = CONSENT_MESSAGE_EVENTS[eventType];
@@ -134,9 +143,8 @@
 
     function onCmpuishown(tcData) {
         if (tcData && tcData.eventStatus === 'cmpuishown') {
-            const adobeTagId = exportedFunctions.getAdobeTagId(window.utag.data['ut.profile']);
             window.utag.data.cmp_events = TCFAPI_COMMON_EVENTS.CMP_UI_SHOWN;
-            window.utag.view(window.utag.data, null, [adobeTagId]);
+            exportedFunctions.sendFirstPageViewEvent();
             // Ensure that view event gets processed before link event by adding a delay.
             setTimeout(() => {
                 exportedFunctions.sendLinkEvent(TCFAPI_COMMON_EVENTS.CMP_UI_SHOWN);

--- a/extensions/cmp_interaction_tracking.js
+++ b/extensions/cmp_interaction_tracking.js
@@ -94,9 +94,10 @@
     }
 
     function hasUserDeclinedConsent() {
-        return window.utag.data['cp.utag_main_cmp_after']
-            && (!window.utag.data.consentedVendors ||
-                window.utag.data.consentedVendors && !window.utag.data.consentedVendors.includes('adobe_analytics'));
+        const hasUserGivenConsent = window.utag.data.consentedVendors && window.utag.data.consentedVendors.includes('adobe_analytics');
+        const isAfterCMP = window.utag.data['cp.utag_main_cmp_after'] ? (window.utag.data['cp.utag_main_cmp_after'].toLowerCase() === 'true') : false;
+
+        return hasUserGivenConsent ? false : isAfterCMP;
     }
 
     function sendLinkEvent(label) {

--- a/extensions/cmp_interaction_tracking.js
+++ b/extensions/cmp_interaction_tracking.js
@@ -60,7 +60,8 @@
         getABTestingProperties,
         onUserConsent,
         sendFirstPageViewEvent,
-        hasUserDeclinedConsent
+        hasUserDeclinedConsent,
+        isAfterCMP
     };
 
     function getABTestingProperties() {
@@ -93,9 +94,13 @@
         exportedFunctions.setABTestingProperties(data);
     }
 
+    function isAfterCMP() {
+        return window.utag.data['cp.utag_main_cmp_after'] ? (window.utag.data['cp.utag_main_cmp_after'].toLowerCase() === 'true') : false;
+    }
+
     function hasUserDeclinedConsent() {
         const hasUserGivenConsent = window.utag.data.consentedVendors && window.utag.data.consentedVendors.includes('adobe_analytics');
-        const isAfterCMP = window.utag.data['cp.utag_main_cmp_after'] ? (window.utag.data['cp.utag_main_cmp_after'].toLowerCase() === 'true') : false;
+        const isAfterCMP = exportedFunctions.isAfterCMP();
 
         return hasUserGivenConsent ? false : isAfterCMP;
     }
@@ -120,7 +125,7 @@
 
     function sendFirstPageViewEvent() {
         // Check if user has already given/declined consent
-        if (!window.utag.data['cp.utag_main_cmp_after']) {
+        if (!exportedFunctions.isAfterCMP()) {
             const adobeTagId = exportedFunctions.getAdobeTagId(window.utag.data['ut.profile']);
             window.utag.view(window.utag.data, null, [adobeTagId]);
         }

--- a/extensions/cmp_interaction_tracking.js
+++ b/extensions/cmp_interaction_tracking.js
@@ -96,8 +96,8 @@
 
     function isAfterCMP() {
         const hasCMPAfterCookie = window.utag.data['cp.utag_main_cmp_after'] ? (window.utag.data['cp.utag_main_cmp_after'].toLowerCase() === 'true') : false;
-        const defaultVendors = 'adobe_cmp';
-        const hasVendors = !!window.utag.data.consentedVendors && window.utag.data.consentedVendors !== defaultVendors;
+        const defaultVendorList = 'adobe_cmp,';
+        const hasVendors = !!window.utag.data.consentedVendors && window.utag.data.consentedVendors !== defaultVendorList;
 
         return hasCMPAfterCookie || hasVendors;
     }

--- a/tests/cmp_interaction_tracking.test.js
+++ b/tests/cmp_interaction_tracking.test.js
@@ -210,23 +210,30 @@ describe('CMP Interaction Tracking', () => {
         });
     });
 
+    describe('isAfterCMP', () =>{
+        it('should return true if user has given a consent decision', function () {
+            window.utag.data['cp.utag_main_cmp_after'] = 'true';
+            const result = cmpInteractionTracking.isAfterCMP();
+            expect(result).toBe(true);
+        });
+
+        it('should return false if user has NOT given a consent decision', function () {
+            const result = cmpInteractionTracking.isAfterCMP();
+            expect(result).toBe(false);
+        });
+    });
+
     describe('hasUserDeclinedConsent()', () => {
         it('should be true if user has declined Adobe tracking', function () {
-            window.utag.data['cp.utag_main_cmp_after'] = 'true';
+            jest.spyOn(cmpInteractionTracking, 'isAfterCMP').mockReturnValue(true);
             window.utag.data.consentedVendors = 'any-vendor';
             const result = cmpInteractionTracking.hasUserDeclinedConsent();
             expect(result).toBe(true);
         });
 
-        it('should be false if user has NOT declined Adobe tracking', function () {
-            window.utag.data['cp.utag_main_cmp_after'] = 'true';
+        it('should be false if user consented to Adobe Analytics tracking', function () {
             window.utag.data.consentedVendors = 'any-vendor,adobe_analytics';
             let result = cmpInteractionTracking.hasUserDeclinedConsent();
-            expect(result).toBe(false);
-
-            window.utag.data['cp.utag_main_cmp_after'] = false;
-            window.utag.data.consentedVendors = 'any-vendor';
-            result = cmpInteractionTracking.hasUserDeclinedConsent();
             expect(result).toBe(false);
         });
     });
@@ -446,13 +453,13 @@ describe('CMP Interaction Tracking', () => {
         });
 
         it('should NOT get the tag ID of the first-page-view tag if user has already given/declined consent', function () {
-            window.utag.data['cp.utag_main_cmp_after'] = true;
+            jest.spyOn(cmpInteractionTracking, 'isAfterCMP').mockReturnValue(true);
             cmpInteractionTracking.sendFirstPageViewEvent();
             expect(cmpInteractionTracking.getAdobeTagId).not.toHaveBeenCalled();
         });
 
         it('should NOT send first-page-view tracking event if user has already given/declined consent', function () {
-            window.utag.data['cp.utag_main_cmp_after'] = true;
+            jest.spyOn(cmpInteractionTracking, 'isAfterCMP').mockReturnValue(true);
             cmpInteractionTracking.sendFirstPageViewEvent();
             expect(window.utag.view).not.toHaveBeenCalled();
         });

--- a/tests/cmp_interaction_tracking.test.js
+++ b/tests/cmp_interaction_tracking.test.js
@@ -234,7 +234,7 @@ describe('CMP Interaction Tracking', () => {
         });
 
         it('should return false if list of consented vendors equals default vendor', function () {
-            window.utag.data.consentedVendors = 'adobe_cmp';
+            window.utag.data.consentedVendors = 'adobe_cmp,';
             const result = cmpInteractionTracking.isAfterCMP();
             expect(result).toBe(false);
         });

--- a/tests/cmp_interaction_tracking.test.js
+++ b/tests/cmp_interaction_tracking.test.js
@@ -222,13 +222,19 @@ describe('CMP Interaction Tracking', () => {
             expect(result).toBe(false);
         });
 
-        it('should return true if list of consented vendors exists', function () {
+        it('should return true if user consented any vendor', function () {
             window.utag.data.consentedVendors = 'any-vendors';
             const result = cmpInteractionTracking.isAfterCMP();
             expect(result).toBe(true);
         });
 
         it('should return false if list of consented vendors does NOT exists', function () {
+            const result = cmpInteractionTracking.isAfterCMP();
+            expect(result).toBe(false);
+        });
+
+        it('should return false if list of consented vendors equals default vendor', function () {
+            window.utag.data.consentedVendors = 'adobe_cmp';
             const result = cmpInteractionTracking.isAfterCMP();
             expect(result).toBe(false);
         });

--- a/tests/cmp_interaction_tracking.test.js
+++ b/tests/cmp_interaction_tracking.test.js
@@ -282,7 +282,8 @@ describe('CMP Interaction Tracking', () => {
         it('should set correct utag.data properties when user gives consent', () => {
             cmpInteractionTracking.onMessageChoiceSelect('any-id', 11);
             expect(window.utag.data).toEqual({
-                'cmp_events': 'cm_accept_all'
+                'cmp_events': 'cm_accept_all',
+                'cp.utag_main_cmp_after': true
             });
         });
 
@@ -306,7 +307,8 @@ describe('CMP Interaction Tracking', () => {
         it('should set correct utag.data properties when user declines consent', () => {
             cmpInteractionTracking.onMessageChoiceSelect('any-id', 13);
             expect(window.utag.data).toEqual({
-                'cmp_events': 'cm_reject_all'
+                'cmp_events': 'cm_reject_all',
+                'cp.utag_main_cmp_after': true
             });
         });
 
@@ -323,16 +325,19 @@ describe('CMP Interaction Tracking', () => {
         it('should set utag_main_cmp_after cookie to true when user gives consent', () => {
             cmpInteractionTracking.onMessageChoiceSelect('test', 11);
             expect(window.utag.loader.SC).toHaveBeenCalledWith('utag_main', {'cmp_after': 'true;exp-session'});
+            expect(window.utag.data['cp.utag_main_cmp_after']).toBe(true);
         });
 
         it('should set utag_main_cmp_after cookie to true when user declines consent', () => {
             cmpInteractionTracking.onMessageChoiceSelect('test', 13);
             expect(window.utag.loader.SC).toHaveBeenCalledWith('utag_main', {'cmp_after': 'true;exp-session'});
+            expect(window.utag.data['cp.utag_main_cmp_after']).toBe(true);
         });
 
         it('should NOT set utag_main_cmp_after cookie when user opens privacy manager', () => {
             cmpInteractionTracking.onMessageChoiceSelect('test', 12);
             expect(window.utag.loader.SC).not.toHaveBeenCalledWith('utag_main', {'cmp_after': 'true;exp-session'});
+            expect(window.utag.data['cp.utag_main_cmp_after']).toBeUndefined();
         });
 
         it('should call onUserConsent() when user has given consent', function () {
@@ -356,7 +361,8 @@ describe('CMP Interaction Tracking', () => {
             cmpInteractionTracking.onPrivacyManagerAction('SAVE_AND_EXIT');
 
             expect(window.utag.data).toEqual({
-                'cmp_events': 'pm_save_and_exit'
+                'cmp_events': 'pm_save_and_exit',
+                'cp.utag_main_cmp_after': true
             });
         });
 
@@ -368,7 +374,8 @@ describe('CMP Interaction Tracking', () => {
         it('should set correct utag.data properties when user gives consent', () => {
             cmpInteractionTracking.onPrivacyManagerAction('ACCEPT_ALL');
             expect(window.utag.data).toEqual({
-                'cmp_events': 'pm_accept_all'
+                'cmp_events': 'pm_accept_all',
+                'cp.utag_main_cmp_after': true
             });
         });
 
@@ -380,7 +387,8 @@ describe('CMP Interaction Tracking', () => {
         it('should set utag.data properties when called with an all purposeConsent', () => {
             cmpInteractionTracking.onPrivacyManagerAction({purposeConsent: 'all'});
             expect(window.utag.data).toEqual({
-                'cmp_events': 'pm_accept_all'
+                'cmp_events': 'pm_accept_all',
+                'cp.utag_main_cmp_after': true
             });
         });
 
@@ -392,7 +400,8 @@ describe('CMP Interaction Tracking', () => {
         it('should set utag.data properties when called with a purposeConsent other from all', () => {
             cmpInteractionTracking.onPrivacyManagerAction({purposeConsent: 'any-purpose-consent'});
             expect(window.utag.data).toEqual({
-                'cmp_events': 'pm_save_and_exit'
+                'cmp_events': 'pm_save_and_exit',
+                'cp.utag_main_cmp_after': true
             });
         });
 
@@ -409,6 +418,7 @@ describe('CMP Interaction Tracking', () => {
         it('should set utag_main_cmp_after cookie to true', () => {
             cmpInteractionTracking.onPrivacyManagerAction('SAVE_AND_EXIT');
             expect(window.utag.loader.SC).toHaveBeenCalledWith('utag_main', {'cmp_after': 'true;exp-session'});
+            expect(window.utag.data['cp.utag_main_cmp_after']).toBe(true);
         });
     });
 

--- a/tests/cmp_interaction_tracking.test.js
+++ b/tests/cmp_interaction_tracking.test.js
@@ -212,14 +212,14 @@ describe('CMP Interaction Tracking', () => {
 
     describe('hasUserDeclinedConsent()', () => {
         it('should be true if user has declined Adobe tracking', function () {
-            window.utag.data['cp.utag_main_cmp_after'] = true;
+            window.utag.data['cp.utag_main_cmp_after'] = 'true';
             window.utag.data.consentedVendors = 'any-vendor';
             const result = cmpInteractionTracking.hasUserDeclinedConsent();
             expect(result).toBe(true);
         });
 
         it('should be false if user has NOT declined Adobe tracking', function () {
-            window.utag.data['cp.utag_main_cmp_after'] = true;
+            window.utag.data['cp.utag_main_cmp_after'] = 'true';
             window.utag.data.consentedVendors = 'any-vendor,adobe_analytics';
             let result = cmpInteractionTracking.hasUserDeclinedConsent();
             expect(result).toBe(false);

--- a/tests/cmp_interaction_tracking.test.js
+++ b/tests/cmp_interaction_tracking.test.js
@@ -211,13 +211,24 @@ describe('CMP Interaction Tracking', () => {
     });
 
     describe('isAfterCMP', () =>{
-        it('should return true if user has given a consent decision', function () {
+        it('should return true if utag_main_cmp_after cookie is set to true', function () {
             window.utag.data['cp.utag_main_cmp_after'] = 'true';
             const result = cmpInteractionTracking.isAfterCMP();
             expect(result).toBe(true);
         });
 
-        it('should return false if user has NOT given a consent decision', function () {
+        it('should return false if utag_main_cmp_after cookie is NOT set to true', function () {
+            const result = cmpInteractionTracking.isAfterCMP();
+            expect(result).toBe(false);
+        });
+
+        it('should return true if list of consented vendors exists', function () {
+            window.utag.data.consentedVendors = 'any-vendors';
+            const result = cmpInteractionTracking.isAfterCMP();
+            expect(result).toBe(true);
+        });
+
+        it('should return false if list of consented vendors does NOT exists', function () {
             const result = cmpInteractionTracking.isAfterCMP();
             expect(result).toBe(false);
         });

--- a/tests/cmp_interaction_tracking.test.js
+++ b/tests/cmp_interaction_tracking.test.js
@@ -525,7 +525,7 @@ describe('CMP Interaction Tracking', () => {
         });
 
         it('should call sendLinkEvent function with correct parameters', function () {
-            const label = 'any-l    abel';
+            const label = 'any-label';
             cmpInteractionTracking.onMessage({
                 data: {
                     cmpLayerMessage: true,


### PR DESCRIPTION
https://as-jira.axelspringer.de/browse/TRAC-1217

Because of the legacy CMP user issue (see comments in ticket) sending of first-page-view tracking request is moved back into the extension. 

This also fixes the issue with wrong first-page-view tracking request when clicking on privacy link in page footer.