### PR TITLE
eVar66_isArticlepage as pageType

### DIFF
--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -355,7 +355,6 @@ s._setKameleoonTracking = function (s) {
  * Homepage teaser tracking
  */
 s._setTeaserTrackingEvars = function (s) {
-    const pageType = s._utils.getDocType();
 
     // Home teaser tracking evars
     if (sessionStorage.getItem('home_teaser_info')

--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -359,7 +359,7 @@ s._setTeaserTrackingEvars = function (s) {
 
     // Home teaser tracking evars
     if (sessionStorage.getItem('home_teaser_info')
-        && (pageType === 'article' || pageType === 'media')
+        && (s._utils.isArticlePage())
         && (s._ppvPreviousPage.indexOf('home') === 0 || s._ppvPreviousPage.indexOf('section') === 0)) {
         s.eVar66 = sessionStorage.getItem('home_teaser_info');
         s.eVar92 = sessionStorage.getItem('home_teaser_info') + '|' + s.eVar1;


### PR DESCRIPTION
home_teaser has to be set at all article pages and not only for pageType 'article' and 'media'.
In case of a reload of an CORE article we send event22 (PV of article from home) without home_teaser. The change should solve this.