### PR TITLE
Trac 1308 cookie domain e var66

### DIFF
--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -361,8 +361,8 @@ s._setTeaserTrackingEvars = function (s) {
         && (s._utils.isArticlePage())
         && (s._ppvPreviousPage.indexOf('home') === 0 || s._ppvPreviousPage.indexOf('section') === 0)) {
         s.eVar66 = window.utag.data['cp.utag_main_hti'];
-        s.eVar66 = window.utag.data['cp.utag_main_hti'] + '|' + s.eVar1;        
-        s.eVar66 = window.utag.data['cp.utag_main_tb'];
+        s.eVar92 = window.utag.data['cp.utag_main_hti'] + '|' + s.eVar1;        
+        s.eVar97 = window.utag.data['cp.utag_main_tb'];
     }
 };
 

--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -360,9 +360,12 @@ s._setTeaserTrackingEvars = function (s) {
     if (sessionStorage.getItem('home_teaser_info')
         && (s._utils.isArticlePage())
         && (s._ppvPreviousPage.indexOf('home') === 0 || s._ppvPreviousPage.indexOf('section') === 0)) {
-        s.eVar66 = sessionStorage.getItem('home_teaser_info');
-        s.eVar92 = sessionStorage.getItem('home_teaser_info') + '|' + s.eVar1;
-        s.eVar97 = sessionStorage.getItem('teaser_block');
+        //s.eVar66 = sessionStorage.getItem('home_teaser_info');
+        s.eVar66 = window.utag.data['cp.utag_main_hti'];
+        //s.eVar92 = sessionStorage.getItem('home_teaser_info') + '|' + s.eVar1;
+        s.eVar66 = window.utag.data['cp.utag_main_hti'] + '|' + s.eVar1;        
+        //s.eVar97 = sessionStorage.getItem('teaser_block');
+        s.eVar66 = window.utag.data['cp.utag_main_tb'];
     }
 };
 

--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -357,7 +357,8 @@ s._setKameleoonTracking = function (s) {
 s._setTeaserTrackingEvars = function (s) {
 
     // Home teaser tracking evars
-    if (sessionStorage.getItem('home_teaser_info')
+    //if (sessionStorage.getItem('home_teaser_info')
+    if (window.utag.data['cp.utag_main_hti'] 
         && (s._utils.isArticlePage())
         && (s._ppvPreviousPage.indexOf('home') === 0 || s._ppvPreviousPage.indexOf('section') === 0)) {
         s.eVar66 = window.utag.data['cp.utag_main_hti'];

--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -360,11 +360,8 @@ s._setTeaserTrackingEvars = function (s) {
     if (sessionStorage.getItem('home_teaser_info')
         && (s._utils.isArticlePage())
         && (s._ppvPreviousPage.indexOf('home') === 0 || s._ppvPreviousPage.indexOf('section') === 0)) {
-        //s.eVar66 = sessionStorage.getItem('home_teaser_info');
         s.eVar66 = window.utag.data['cp.utag_main_hti'];
-        //s.eVar92 = sessionStorage.getItem('home_teaser_info') + '|' + s.eVar1;
         s.eVar66 = window.utag.data['cp.utag_main_hti'] + '|' + s.eVar1;        
-        //s.eVar97 = sessionStorage.getItem('teaser_block');
         s.eVar66 = window.utag.data['cp.utag_main_tb'];
     }
 };

--- a/tests/doplugins/doplugins_teaser_tracking_evars.test.js
+++ b/tests/doplugins/doplugins_teaser_tracking_evars.test.js
@@ -19,7 +19,7 @@ describe('_setTeaserTrackingEvars', () => {
 
     });
 
-    it('should set eVar66, eVar92 and eVar97 if utag_main cookie contains home_teaser_info, page type is article or video and _ppvPreviousPage contains home', () => {
+    it('clicks at Teaser at BILD HOMEPAGE should set home_teaser_info and teaser_block in utag_main Cookie. Then eVars66/92/92 are set for the following Page View of all article types and event22', () => {
 
         window.utag.data['cp.utag_main_hti'] = 'test_home_teaser_info';
         window.utag.data['cp.utag_main_tb'] = 'test_teaser_block';
@@ -35,7 +35,7 @@ describe('_setTeaserTrackingEvars', () => {
 
     });
 
-    it('should not set eVar66 and eVar92 if  utag_main cookie does not contain home_teaser_info, page type is not article or video or _ppvPreviousPage does not contain home', () => {
+    it('home_teaser_info and teaser_block are only set with event22 at all article types ', () => {
         s._setTeaserTrackingEvars(s);
 
         expect(s.eVar66).toBeUndefined();

--- a/tests/doplugins/doplugins_teaser_tracking_evars.test.js
+++ b/tests/doplugins/doplugins_teaser_tracking_evars.test.js
@@ -15,12 +15,13 @@ describe('_setTeaserTrackingEvars', () => {
 
     afterEach(() => {
         jest.restoreAllMocks();
-        sessionStorage.removeItem('home_teaser_info');
+        window.utag.loader.SC('utag_main', {'hti':'', 'tb':''}, 'session');
     });
 
     it('should set eVar66, eVar92 and eVar97 if session storage contains home_teaser_info, page type is article or video and _ppvPreviousPage contains home', () => {
-        sessionStorage.setItem('home_teaser_info', 'test_home_teaser_info');
-        sessionStorage.setItem('teaser_block', 'test_teaser_block');
+
+        window.utag.loader.SC('utag_main', {'hti':'test_home_teaser_info', 'tb':'test_teaser_block'}, 'session');
+
         window.utag.data.page_type = 'article';
         s._ppvPreviousPage = 'home';
         s.eVar1 = 'test';

--- a/tests/doplugins/doplugins_teaser_tracking_evars.test.js
+++ b/tests/doplugins/doplugins_teaser_tracking_evars.test.js
@@ -19,7 +19,7 @@ describe('_setTeaserTrackingEvars', () => {
 
     });
 
-    it('clicks at Teaser at BILD HOMEPAGE should set home_teaser_info and teaser_block in utag_main Cookie. Then eVars66/92/92 are set for the following Page View of all article types and event22', () => {
+    it('should set a campaign value to certain eVars if a user has opened an article through a homepage teaser', () => {
 
         window.utag.data['cp.utag_main_hti'] = 'test_home_teaser_info';
         window.utag.data['cp.utag_main_tb'] = 'test_teaser_block';
@@ -35,10 +35,11 @@ describe('_setTeaserTrackingEvars', () => {
 
     });
 
-    it('home_teaser_info and teaser_block are only set with event22 at all article types ', () => {
+    it('should not set campaign values on non article pages', () => {
         s._setTeaserTrackingEvars(s);
 
         expect(s.eVar66).toBeUndefined();
         expect(s.eVar92).toBeUndefined();
+        expect(s.eVar97).toBeUndefined();        
     });
 });

--- a/tests/doplugins/doplugins_teaser_tracking_evars.test.js
+++ b/tests/doplugins/doplugins_teaser_tracking_evars.test.js
@@ -11,17 +11,18 @@ describe('_setTeaserTrackingEvars', () => {
 
         // Provide a fresh copy of the s-object for each test.
         s = { ...sObject };
+
     });
 
     afterEach(() => {
         jest.restoreAllMocks();
-        window.utag.loader.SC('utag_main', {'hti':'', 'tb':''}, 'session');
+
     });
 
-    it('should set eVar66, eVar92 and eVar97 if session storage contains home_teaser_info, page type is article or video and _ppvPreviousPage contains home', () => {
+    it('should set eVar66, eVar92 and eVar97 if utag_main cookie contains home_teaser_info, page type is article or video and _ppvPreviousPage contains home', () => {
 
-        window.utag.loader.SC('utag_main', {'hti':'test_home_teaser_info', 'tb':'test_teaser_block'}, 'session');
-
+        window.utag.data['cp.utag_main_hti'] = 'test_home_teaser_info';
+        window.utag.data['cp.utag_main_tb'] = 'test_teaser_block';
         window.utag.data.page_type = 'article';
         s._ppvPreviousPage = 'home';
         s.eVar1 = 'test';
@@ -34,7 +35,7 @@ describe('_setTeaserTrackingEvars', () => {
 
     });
 
-    it('should not set eVar66 and eVar92 if session storage does not contain home_teaser_info, page type is not article or video or _ppvPreviousPage does not contain home', () => {
+    it('should not set eVar66 and eVar92 if  utag_main cookie does not contain home_teaser_info, page type is not article or video or _ppvPreviousPage does not contain home', () => {
         s._setTeaserTrackingEvars(s);
 
         expect(s.eVar66).toBeUndefined();


### PR DESCRIPTION
switch from sessionStorage to utag_main cookie
home_teaser_info and block_info are now read out from utag_main Cookie. utag_main cookie is without. subdomains stored (.bild.de)