### PR TITLE
Trac 1375 bild adobe doc type

### DIFF
--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -54,7 +54,6 @@ s._utils = {
         return window.utag.data.page_type
             || window.utag.data.page_mapped_doctype_for_pagename
             || window.utag.data.page_document_type
-            || window.utag.data.adobe_doc_type
             || window.utag.data.adobe_docType
             || window.utag.data.ad_page_document_type
             || '';
@@ -324,7 +323,7 @@ s._articleViewTypeObj = {
     setViewTypes: function (s) {
         const pageViewType = window.document.referrer ? this.getViewTypeByReferrer() : this.getViewTypeByTrackingProperty();
 
-        if (window.utag.data.adobe_doc_type != 'ad wall') {
+        if (window.utag.data.page_mapped_doctype_for_pagename != 'ad wall') {
 
             if (s._utils.isArticlePage()) {
                 s._articleViewType = s.eVar44 = pageViewType;
@@ -470,15 +469,15 @@ s._bildPageNameObj = {
     },
 
     isAdWall: function (s) {
-        return !!s.pageName && (s.pageName.indexOf('42925516') !== -1
-            || s.pageName.indexOf('54578900') !== -1);
+        return (!!s.pageName && (s.pageName.indexOf('42925516') !== -1
+            || s.pageName.indexOf('54578900') !== -1) || window.utag.data['dom.pathname'].indexOf('adblockwall.html') !== -1);
     },
 
     isLive: function () {
         return !!this.isDocTypeArticle() && !!window.utag.data.page_cms_path
             && window.utag.data.page_cms_path.indexOf('im-live-ticker') !== -1;
     },
-
+ 
     isLiveSport: function () {
         return !!this.isDocTypeArticle() && !!window.utag.data.page_cms_path
             && (window.utag.data.page_cms_path.indexOf('im-liveticker') !== -1
@@ -487,7 +486,7 @@ s._bildPageNameObj = {
 
     setPageName: function (s) {
         if (this.isAdWall(s)) {
-            window.utag.data.adobe_doc_type = 'ad wall';
+            window.utag.data.page_mapped_doctype_for_pagename = 'ad wall';
             s.pageName = 'ad wall : ' + s.eVar1;
             s.eVar3 = 'ad wall';
             s.prop3 = 'ad wall';
@@ -499,12 +498,12 @@ s._bildPageNameObj = {
             s.eVar5 = 'home';
             s.pageName = 'home : ' + window.utag.data['page_id'];
         } else if (this.isLive()) {
-            window.utag.data.adobe_doc_type = 'live';
+            window.utag.page_mapped_doctype_for_pagename = 'live';
             s.eVar3 = 'live';
             s.prop3 = 'live';
             s.pageName = 'live : ' + window.utag.data['page_id'];
         } else if (this.isLiveSport()) {
-            window.utag.data.adobe_doc_type = 'live-sport';
+            window.utag.page_mapped_doctype_for_pagename = 'live-sport';
             s.eVar3 = 'live-sport';
             s.prop3 = 'live-sport';
             s.pageName = 'live-sport : ' + window.utag.data['page_id'];

--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -498,12 +498,12 @@ s._bildPageNameObj = {
             s.eVar5 = 'home';
             s.pageName = 'home : ' + window.utag.data['page_id'];
         } else if (this.isLive()) {
-            window.utag.page_mapped_doctype_for_pagename = 'live';
+            window.utag.data.page_mapped_doctype_for_pagename = 'live';
             s.eVar3 = 'live';
             s.prop3 = 'live';
             s.pageName = 'live : ' + window.utag.data['page_id'];
         } else if (this.isLiveSport()) {
-            window.utag.page_mapped_doctype_for_pagename = 'live-sport';
+            window.utag.data.page_mapped_doctype_for_pagename = 'live-sport';
             s.eVar3 = 'live-sport';
             s.prop3 = 'live-sport';
             s.pageName = 'live-sport : ' + window.utag.data['page_id'];

--- a/tests/doplugins/doplugins_bild_page_name.test.js
+++ b/tests/doplugins/doplugins_bild_page_name.test.js
@@ -24,14 +24,14 @@ describe('_bildPageNameObj', () => {
             getDocTypeMock = jest.spyOn(s._utils, 'getDocType').mockImplementation();
         });
 
-        it('should be false if adobe_doc_type is not article', () => {
+        it('should be false if page_mapped_doctype_for_pagename is not article', () => {
             getDocTypeMock.mockReturnValue('any-non-article-type');
 
             const returnValue = s._bildPageNameObj.isDocTypeArticle();
             expect(returnValue).toBe(false);
         });
 
-        it('should be true if adobe_doc_type is article', () => {
+        it('should be true if page_mapped_doctype_for_pagename is article', () => {
             getDocTypeMock.mockReturnValue('article');
 
             const returnValue = s._bildPageNameObj.isDocTypeArticle();
@@ -92,7 +92,7 @@ describe('_bildPageNameObj', () => {
     });
 
     describe('isLive', () => {
-        it('should be false if adobe_doc_type is not article', () => {
+        it('should be false if page_mapped_doctype_for_pagename is not article', () => {
             window.utag.data.page_cms_path = 'test/im-live-ticker';
             window.utag.data.page_mapped_doctype_for_pagename = 'home';
 
@@ -108,7 +108,7 @@ describe('_bildPageNameObj', () => {
             expect(returnValue).toBe(false);
         });
 
-        it('should be true if adobe_doc_type is article and page_cms_path contains im-live-ticker', () => {
+        it('should be true if page_mapped_doctype_for_pagename is article and page_cms_path contains im-live-ticker', () => {
             window.utag.data.page_cms_path = 'test/im-live-ticker';
             window.utag.data.page_mapped_doctype_for_pagename = 'article';
 
@@ -118,7 +118,7 @@ describe('_bildPageNameObj', () => {
     });
 
     describe('isLiveSport', () => {
-        it('should be false if adobe_doc_type is not article', () => {
+        it('should be false if page_mapped_doctype_for_pagename is not article', () => {
             window.utag.data.page_cms_path = 'test/im-liveticker';
             window.utag.data.page_mapped_doctype_for_pagename = 'home';
 
@@ -135,7 +135,7 @@ describe('_bildPageNameObj', () => {
         });
 
 
-        it('should be true if adobe_doc_type is article and page_cms_path contains im-liveticker', () => {
+        it('should be true if page_mapped_doctype_for_pagename is article and page_cms_path contains im-liveticker', () => {
             window.utag.data.page_cms_path = 'test/im-liveticker';
             window.utag.data.page_mapped_doctype_for_pagename = 'article';
 
@@ -143,7 +143,7 @@ describe('_bildPageNameObj', () => {
             expect(returnValue).toBe(true);
         });
 
-        it('should be true if adobe_doc_type is article and page_cms_path contains /liveticker/', () => {
+        it('should be true if page_mapped_doctype_for_pagename is article and page_cms_path contains /liveticker/', () => {
             window.utag.data.page_cms_path = 'test/liveticker/';
             window.utag.data.page_mapped_doctype_for_pagename = 'article';
 
@@ -172,7 +172,6 @@ describe('_bildPageNameObj', () => {
         it('should not set any data if isAdWall, isHome, isLive, isLiveSport are all false', () => {
             s._bildPageNameObj.setPageName(s);
 
-            //expect(window.utag.data.adobe_doc_type).toBeUndefined();
             expect(window.utag.data.page_mapped_doctype_for_pagename).toBeUndefined();
             expect(s.pageName).toBeUndefined();
             expect(s.eVar3).toBeUndefined();

--- a/tests/doplugins/doplugins_bild_page_name.test.js
+++ b/tests/doplugins/doplugins_bild_page_name.test.js
@@ -66,6 +66,7 @@ describe('_bildPageNameObj', () => {
     describe('isAdWall', () => {
         it('should be false if pageName is incorrect', () => {
             s.pageName = 'test-12345678';
+            window.utag.data['dom.pathname'] = 'any-value';
             const returnValue = s._bildPageNameObj.isAdWall(s);
             expect(returnValue).toBe(false);
         });

--- a/tests/doplugins/doplugins_bild_page_name.test.js
+++ b/tests/doplugins/doplugins_bild_page_name.test.js
@@ -82,12 +82,18 @@ describe('_bildPageNameObj', () => {
             expect(returnValue).toBe(true);
         });
 
+        it('should be true if utag.data.dom.pathname contains adblockwall.html', () => {
+            window.utag.data['dom.pathname'] = 'adblockwall.html';
+            const returnValue = s._bildPageNameObj.isAdWall(s);
+            expect(returnValue).toBe(true);
+        });
+
     });
 
     describe('isLive', () => {
         it('should be false if adobe_doc_type is not article', () => {
             window.utag.data.page_cms_path = 'test/im-live-ticker';
-            window.utag.data.adobe_doc_type = 'home';
+            window.utag.data.page_mapped_doctype_for_pagename = 'home';
 
             const returnValue = s._bildPageNameObj.isLive();
             expect(returnValue).toBe(false);
@@ -95,7 +101,7 @@ describe('_bildPageNameObj', () => {
 
         it('should be false if page_cms_path is not correct', () => {
             window.utag.data.page_cms_path = 'test/imliveticker';
-            window.utag.data.adobe_doc_type = 'article';
+            window.utag.data.page_mapped_doctype_for_pagename = 'article';
 
             const returnValue = s._bildPageNameObj.isLive();
             expect(returnValue).toBe(false);
@@ -103,7 +109,7 @@ describe('_bildPageNameObj', () => {
 
         it('should be true if adobe_doc_type is article and page_cms_path contains im-live-ticker', () => {
             window.utag.data.page_cms_path = 'test/im-live-ticker';
-            window.utag.data.adobe_doc_type = 'article';
+            window.utag.data.page_mapped_doctype_for_pagename = 'article';
 
             const returnValue = s._bildPageNameObj.isLive();
             expect(returnValue).toBe(true);
@@ -113,7 +119,7 @@ describe('_bildPageNameObj', () => {
     describe('isLiveSport', () => {
         it('should be false if adobe_doc_type is not article', () => {
             window.utag.data.page_cms_path = 'test/im-liveticker';
-            window.utag.data.adobe_doc_type = 'home';
+            window.utag.data.page_mapped_doctype_for_pagename = 'home';
 
             const returnValue = s._bildPageNameObj.isLiveSport();
             expect(returnValue).toBe(false);
@@ -121,7 +127,7 @@ describe('_bildPageNameObj', () => {
 
         it('should be false if page_cms_path is not correct', () => {
             window.utag.data.page_cms_path = 'test/imliveticker';
-            window.utag.data.adobe_doc_type = 'article';
+            window.utag.data.page_mapped_doctype_for_pagename = 'article';
 
             const returnValue = s._bildPageNameObj.isLiveSport();
             expect(returnValue).toBe(false);
@@ -130,7 +136,7 @@ describe('_bildPageNameObj', () => {
 
         it('should be true if adobe_doc_type is article and page_cms_path contains im-liveticker', () => {
             window.utag.data.page_cms_path = 'test/im-liveticker';
-            window.utag.data.adobe_doc_type = 'article';
+            window.utag.data.page_mapped_doctype_for_pagename = 'article';
 
             const returnValue = s._bildPageNameObj.isLiveSport();
             expect(returnValue).toBe(true);
@@ -138,7 +144,7 @@ describe('_bildPageNameObj', () => {
 
         it('should be true if adobe_doc_type is article and page_cms_path contains /liveticker/', () => {
             window.utag.data.page_cms_path = 'test/liveticker/';
-            window.utag.data.adobe_doc_type = 'article';
+            window.utag.data.page_mapped_doctype_for_pagename = 'article';
 
             const returnValue = s._bildPageNameObj.isLiveSport();
             expect(returnValue).toBe(true);
@@ -165,7 +171,7 @@ describe('_bildPageNameObj', () => {
         it('should not set any data if isAdWall, isHome, isLive, isLiveSport are all false', () => {
             s._bildPageNameObj.setPageName(s);
 
-            expect(window.utag.data.adobe_doc_type).toBeUndefined();
+            //expect(window.utag.data.adobe_doc_type).toBeUndefined();
             expect(window.utag.data.page_mapped_doctype_for_pagename).toBeUndefined();
             expect(s.pageName).toBeUndefined();
             expect(s.eVar3).toBeUndefined();
@@ -178,7 +184,7 @@ describe('_bildPageNameObj', () => {
             isAdWall.mockReturnValue(true);
             s._bildPageNameObj.setPageName(s);
 
-            expect(window.utag.data.adobe_doc_type).toBe('ad wall');
+            expect(window.utag.data.page_mapped_doctype_for_pagename).toBe('ad wall');
             expect(s.pageName).toBe('ad wall : ' + s.eVar1);
             expect(s.eVar3).toBe('ad wall');
             expect(s.prop3).toBe('ad wall');
@@ -203,7 +209,7 @@ describe('_bildPageNameObj', () => {
             isLive.mockReturnValue(true);
             s._bildPageNameObj.setPageName(s);
 
-            expect(window.utag.data.adobe_doc_type).toBe('live');
+            expect(window.utag.data.page_mapped_doctype_for_pagename).toBe('live');
             expect(s.eVar3).toBe('live');
             expect(s.prop3).toBe('live');
             expect(s.pageName).toBe('live : ' + window.utag.data.page_id);
@@ -214,7 +220,7 @@ describe('_bildPageNameObj', () => {
             isLiveSport.mockReturnValue(true);
             s._bildPageNameObj.setPageName(s);
 
-            expect(window.utag.data.adobe_doc_type).toBe('live-sport');
+            expect(window.utag.data.page_mapped_doctype_for_pagename).toBe('live-sport');
             expect(s.eVar3).toBe('live-sport');
             expect(s.prop3).toBe('live-sport');
             expect(s.pageName).toBe('live-sport : ' + window.utag.data.page_id);

--- a/tests/doplugins/doplugins_scroll_depth.test.js
+++ b/tests/doplugins/doplugins_scroll_depth.test.js
@@ -26,28 +26,28 @@ describe('_scrollDepthObj', () => {
         });
 
         it('should return true if doc_type is article', () => {
-            window.utag.data.adobe_doc_type = 'article';
+            window.utag.data.page_mapped_doctype_for_pagename = 'article';
             const result = s._scrollDepthObj.isValidDocType(s);
 
             expect(result).toBe(true);
         });
 
         it('should return true if doc_type is video', () => {
-            window.utag.data.adobe_doc_type = 'video';
+            window.utag.data.page_mapped_doctype_for_pagename = 'video';
             const result = s._scrollDepthObj.isValidDocType(s);
 
             expect(result).toBe(true);
         });
 
         it('should return true if doc_type is single', () => {
-            window.utag.data.adobe_doc_type = 'single';
+            window.utag.data.page_mapped_doctype_for_pagename = 'single';
             const result = s._scrollDepthObj.isValidDocType(s);
 
             expect(result).toBe(true);
         });
 
         it('should return true if doc_type is post', () => {
-            window.utag.data.adobe_doc_type = 'post';
+            window.utag.data.page_mapped_doctype_for_pagename = 'post';
             const result = s._scrollDepthObj.isValidDocType(s);
 
             expect(result).toBe(true);

--- a/tests/doplugins/doplugins_utils.test.js
+++ b/tests/doplugins/doplugins_utils.test.js
@@ -86,7 +86,6 @@ describe('s_utils', () => {
                 'page_type',
                 'page_document_type',
                 'adobe_docType',
-                'adobe_doc_type',
                 'ad_page_document_type',
                 'page_mapped_doctype_for_pagename'];
 


### PR DESCRIPTION
Key adobe_doc_type is history. Its no longer an extra sausage.
adobe_doc_type is removed from bild profiles and has merged into page_mapped_document_type for BILD only.
It also solves problem with event2 and event3/4 on article and ad wall pages of CORE and LEAN. 

Its testable on dev/qa in bild, bild-bild.de and bild-offer.