### PR TITLE
Trac 1393

### DIFF
--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -143,13 +143,6 @@ s._articleViewTypeObj = {
         return referringDomainSegments[referringDomainSegments.length - 2] === documentDomainSegments[documentDomainSegments.length - 2];
     },
 
-    isSport: function (domain) {
-        const sportDomains = ['m.sportdaten.bild.de', 'sportdaten.bild.de', 'm.sport.bild.de', 'sport.bild.de', 'sportdaten.welt.de'];
-
-        return sportDomains.some(item => {
-            return domain.indexOf(item) !== -1;
-        });
-    },
     //Only certain subdomains are considered as homepages: eg. www.bild.de, m.bild.de, sportbild.bild.de
     //Other special subdomains should not be considered: eg. sport.bild.de, online.welt.de
     isHomepageSubdomain: function (domain) {
@@ -489,7 +482,8 @@ s._bildPageNameObj = {
         return !!this.isDocTypeArticle()
             &&!!window.utag.data.page_cms_path
             && (window.utag.data.page_cms_path.indexOf('im-liveticker') !== -1
-                || window.utag.data.page_cms_path.indexOf('/liveticker/') !== -1);
+                || window.utag.data.page_cms_path.indexOf('/liveticker/') !== -1)
+            && !this.isLive();
     },
 
     setPageName: function (s) {
@@ -510,7 +504,7 @@ s._bildPageNameObj = {
             s.eVar3 = 'live';
             s.prop3 = 'live';
             s.pageName = 'live : ' + window.utag.data['page_id'];
-        } else if (this.isLiveSport() && !this.isLive()) {
+        } else if (this.isLiveSport()) {
             window.utag.data.page_mapped_doctype_for_pagename = 'live-sport';
             s.eVar3 = 'live-sport';
             s.prop3 = 'live-sport';

--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -474,8 +474,8 @@ s._bildPageNameObj = {
     },
 
     isLive: function () {
-        return !!this.isDocTypeArticle() && !!window.utag.data.page_cms_path
-            && window.utag.data.page_cms_path.indexOf('im-live-ticker') !== -1;
+        return !!this.isDocTypeArticle() && !!window.utag.data.is_page_live_article
+            && window.utag.data.is_page_live_article === '1';
     },
  
     isLiveSport: function () {

--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -143,6 +143,13 @@ s._articleViewTypeObj = {
         return referringDomainSegments[referringDomainSegments.length - 2] === documentDomainSegments[documentDomainSegments.length - 2];
     },
 
+    isSport: function (domain) {
+        const sportDomains = ['m.sportdaten.bild.de', 'sportdaten.bild.de', 'm.sport.bild.de', 'sport.bild.de', 'sportdaten.welt.de'];
+
+        return sportDomains.some(item => {
+            return domain.indexOf(item) !== -1;
+        });
+    },
     //Only certain subdomains are considered as homepages: eg. www.bild.de, m.bild.de, sportbild.bild.de
     //Other special subdomains should not be considered: eg. sport.bild.de, online.welt.de
     isHomepageSubdomain: function (domain) {
@@ -476,10 +483,11 @@ s._bildPageNameObj = {
     isLive: function () {
         return !!this.isDocTypeArticle() && !!window.utag.data.is_page_live_article
             && window.utag.data.is_page_live_article === '1';
-    },
+    }, 
  
     isLiveSport: function () {
-        return !!this.isDocTypeArticle() && !!window.utag.data.page_cms_path
+        return !!this.isDocTypeArticle()
+            &&!!window.utag.data.page_cms_path
             && (window.utag.data.page_cms_path.indexOf('im-liveticker') !== -1
                 || window.utag.data.page_cms_path.indexOf('/liveticker/') !== -1);
     },
@@ -502,7 +510,7 @@ s._bildPageNameObj = {
             s.eVar3 = 'live';
             s.prop3 = 'live';
             s.pageName = 'live : ' + window.utag.data['page_id'];
-        } else if (this.isLiveSport()) {
+        } else if (this.isLiveSport() && !this.isLive()) {
             window.utag.data.page_mapped_doctype_for_pagename = 'live-sport';
             s.eVar3 = 'live-sport';
             s.prop3 = 'live-sport';

--- a/tests/doplugins/doplugins_bild_page_name.test.js
+++ b/tests/doplugins/doplugins_bild_page_name.test.js
@@ -156,6 +156,7 @@ describe('_bildPageNameObj', () => {
         let isHome;
         let isAdWall;
         let isLive;
+        let isSport;
         let isLiveSport;
 
         beforeEach(() => {
@@ -217,6 +218,7 @@ describe('_bildPageNameObj', () => {
 
         it('should set relevant data if isLiveSport is true', () => {
             window.utag.data.page_id = '12345678';
+            isLive.mockReturnValue(false);
             isLiveSport.mockReturnValue(true);
             s._bildPageNameObj.setPageName(s);
 

--- a/tests/doplugins/doplugins_bild_page_name.test.js
+++ b/tests/doplugins/doplugins_bild_page_name.test.js
@@ -156,7 +156,6 @@ describe('_bildPageNameObj', () => {
         let isHome;
         let isAdWall;
         let isLive;
-        let isSport;
         let isLiveSport;
 
         beforeEach(() => {

--- a/tests/doplugins/doplugins_bild_page_name.test.js
+++ b/tests/doplugins/doplugins_bild_page_name.test.js
@@ -93,23 +93,23 @@ describe('_bildPageNameObj', () => {
 
     describe('isLive', () => {
         it('should be false if page_mapped_doctype_for_pagename is not article', () => {
-            window.utag.data.page_cms_path = 'test/im-live-ticker';
+            window.utag.data.is_page_live_article = '1';
             window.utag.data.page_mapped_doctype_for_pagename = 'home';
 
             const returnValue = s._bildPageNameObj.isLive();
             expect(returnValue).toBe(false);
         });
 
-        it('should be false if page_cms_path is not correct', () => {
-            window.utag.data.page_cms_path = 'test/imliveticker';
+        it('should be false if is_page_live_article is not correct', () => {
+            window.utag.data.is_page_live_article = '0';
             window.utag.data.page_mapped_doctype_for_pagename = 'article';
 
             const returnValue = s._bildPageNameObj.isLive();
             expect(returnValue).toBe(false);
         });
 
-        it('should be true if page_mapped_doctype_for_pagename is article and page_cms_path contains im-live-ticker', () => {
-            window.utag.data.page_cms_path = 'test/im-live-ticker';
+        it('should be true if page_mapped_doctype_for_pagename is article and is_page_live_article is 1', () => {
+            window.utag.data.is_page_live_article = '1';
             window.utag.data.page_mapped_doctype_for_pagename = 'article';
 
             const returnValue = s._bildPageNameObj.isLive();


### PR DESCRIPTION
Only CORE:
All articles that includes a Live Ticker Element set utag.data.is_page_live_article = "1". Thats valid for all regular but not for sport article/ticker. For sport the current rules does not changed.