### PR TITLE
Trac 1415 tracking value before referrer

### DIFF
--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -342,7 +342,9 @@ s._articleViewTypeObj = {
     },
 
     setViewTypes: function (s) {
-        const pageViewType = window.document.referrer ? this.getViewTypeByReferrer() : this.getViewTypeByTrackingProperty();
+        //const pageViewType = window.document.referrer ? this.getViewTypeByReferrer() : this.getViewTypeByTrackingProperty();
+        const trackingValue = this.getTrackingValue();
+        const pageViewType = trackingValue ? this.getViewTypeByTrackingProperty() : this.getViewTypeByReferrer();
 
         if (!s._utils.isAdWall(s)) {
             if (s._utils.isArticlePage()) {

--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -342,7 +342,6 @@ s._articleViewTypeObj = {
     },
 
     setViewTypes: function (s) {
-        //const pageViewType = window.document.referrer ? this.getViewTypeByReferrer() : this.getViewTypeByTrackingProperty();
         const trackingValue = this.getTrackingValue();
         const pageViewType = trackingValue ? this.getViewTypeByTrackingProperty() : this.getViewTypeByReferrer();
 

--- a/tests/doplugins/doplugins_article_view_type.test.js
+++ b/tests/doplugins/doplugins_article_view_type.test.js
@@ -701,7 +701,7 @@ describe('articleViewType()', () => {
         it('should evaluate tracking URL param when referrer is NOT available', function () {
             isArticlePageMock.mockReturnValue(true);
             isAdWallMock.mockReturnValue(false);
-            window.document.referrer = '';
+            window.location.search = 'cid=any-cid';
             s._articleViewTypeObj.setViewTypes(s);
             expect(getViewTypeByTrackingPropertyMock).toHaveBeenCalled();
         });
@@ -710,6 +710,7 @@ describe('articleViewType()', () => {
             const anyViewType = 'any-view-type';
             isAdWallMock.mockReturnValue(false);
             isArticlePageMock.mockReturnValue(true);
+            window.location.search = 'cid=any-cid';
             getViewTypeByTrackingPropertyMock.mockReturnValue(anyViewType);
 
             expect(s._articleViewType).toBeUndefined();
@@ -763,6 +764,7 @@ describe('articleViewType()', () => {
             const anyViewType = 'any-view-type';
             isAdWallMock.mockReturnValue(false);
             isArticlePageMock.mockReturnValue(true);
+            window.location.search = 'cid=any-cid';
             getViewTypeByTrackingPropertyMock.mockReturnValue(anyViewType);
 
             s._articleViewTypeObj.setViewTypes(s);


### PR DESCRIPTION
The starting point for each channel/pageview event has to be the trackingValue (cid,wtrid,wtmc). With this PR we change the order to trackingValue first.