### PR TITLE
t_ref get parameter from utag.data

### DIFF
--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -103,8 +103,18 @@ s._utils = {
         }
         return this.isValidURL(referrerFromHash) ? referrerFromHash : '';
     },
+
+    getReferrerFromGetParameter: function () {
+        let referrerFromGetParameter;
+        if (window.utag.data['qp.t_ref']) {
+            referrerFromGetParameter = window.utag.data['qp.t_ref'];
+            referrerFromGetParameter = decodeURIComponent(referrerFromGetParameter);
+        }
+        return this.isValidURL(referrerFromGetParameter) ? referrerFromGetParameter : '';
+    },
+
     getReferrer: function () {
-        return this.getReferrerFromLocationHash() || window.document.referrer;
+        return this.getReferrerFromLocationHash() || this.getReferrerFromGetParameter() || window.document.referrer;
     },
     getReferringDomain: function () {
         return this.getDomainFromURLString(this.getReferrer());

--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -555,6 +555,11 @@ s._bildPageNameObj = {
             s.pageName = 'live-sport : ' + window.utag.data['page_id'];
         }
     },
+
+    //Get Parameter t_ref for Mobile Switcher 
+    setReferrerFromGetParameter: function (s){
+        s.eVar53 = this.getReferrerFromGetParameter() || '';
+    }
 };
 
 /**

--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -691,7 +691,7 @@ s._T_REFTracking = {
             // nothing to do here
         }
 
-        s.eVar53 = tref;
+        s.eVar53 = s.eVar53 ? s.eVar53 + 't_ref=' + tref : 't_ref=' + tref;
     }
 };
 

--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -691,7 +691,7 @@ s._T_REFTracking = {
             // nothing to do here
         }
 
-        s.eVar53 = s.eVar53 ? s.eVar53 + 't_ref=' + tref : 't_ref=' + tref;
+        s.eVar53 = s.eVar53 ? s.eVar53 + '|t_ref=' + tref : 't_ref=' + tref;
     }
 };
 
@@ -802,6 +802,8 @@ s._init = function (s) {
 
     s.trackExternalLinks = true;
     s.eVar61 = window.navigator.userAgent;
+
+    s.eVar53 = window.utag.data['dom.hash'] || '';
 
     //Referrer for link events
     s.referrer = s._utils.getReferrer();

--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -556,10 +556,6 @@ s._bildPageNameObj = {
         }
     },
 
-    //Get Parameter t_ref for Mobile Switcher 
-    setReferrerFromGetParameter: function (s){
-        s.eVar53 = this.getReferrerFromGetParameter() || '';
-    }
 };
 
 /**
@@ -678,6 +674,24 @@ s._ICIDTracking = {
         }
 
         s.eVar78 = s.eVar79 = icid;
+    }
+};
+
+/**
+ * Mobile Switcher Get Parameter t_ref
+ * (replacement of wt_ref)
+ */
+s._T_REFTracking = {
+    setVariables: function (s) {
+        let tref = '';
+        try {
+            const queryParams = new URLSearchParams(window.location.search);
+            tref = queryParams.get('t_ref') ? queryParams.get('t_ref') : '';
+        } catch (error) {
+            // nothing to do here
+        }
+
+        s.eVar53 = tref;
     }
 };
 
@@ -804,6 +818,7 @@ s._init = function (s) {
     s._setExternalReferringDomainEvents(s);
     s._plusDensityObj.setDensity(s);
     s._directOutbrainOrderObj.setOutbrain(s);
+    s._T_REFTracking.setVariables(s);
 };
 
 /**


### PR DESCRIPTION
The Mobile Switcher send us in hash **###wt_ref** the original referrer before the page was redirected. 
Starting now we will **also** use the get parameter **t_ref** which we read out of the data layer. 
Logic will be the same... but 
Devs will remove immediately the ###wt_ref. 