### PR TITLE
URL Parameter tbl added (books only)

### DIFF
--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -547,6 +547,10 @@ s._homeTeaserTrackingObj = {
         return teaserBrand || window.utag.data['cp.utag_main_hti'] || window.utag.data['qp.dtp'];
     },
 
+    getBlockValue: function () {
+        const teaserBlock = this.getTeaserBrandFromCID();
+        return teaserBlock || window.utag.data['cp.utag_main_tb'] || window.utag.data['qp.tbl'];
+    },
     deleteTrackingValuesFromCookie: function () {
         window.utag.loader.SC('utag_main', { 'hti': '' + ';exp-session' });
         window.utag.loader.SC('utag_main', { 'tb': '' + ';exp-session' });
@@ -554,10 +558,11 @@ s._homeTeaserTrackingObj = {
 
     setEvars: function (s) {
         const trackingValue = this.getTrackingValue();
+        const blockValue = this.getBlockValue();
         if (trackingValue) {
             s.eVar66 = trackingValue;
             s.eVar92 = trackingValue + '|' + window.utag.data.page_id;
-            s.eVar97 = window.utag.data['cp.utag_main_tb'] || '';
+            s.eVar97 = window.utag.data['cp.utag_main_tb'] || blockValue || '';
         }
     },
 

--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -544,12 +544,12 @@ s._homeTeaserTrackingObj = {
 
     getTrackingValue: function () {
         const teaserBrand = this.getTeaserBrandFromCID();
-        return teaserBrand || window.utag.data['cp.utag_main_hti'] || window.utag.data['qp.dtp'];
+        return teaserBrand || window.utag.data['cp.utag_main_hti'] || window.utag.data['qp.dtp'] || '';
     },
 
     getBlockValue: function () {
         const teaserBlock = this.getTeaserBrandFromCID();
-        return teaserBlock || window.utag.data['cp.utag_main_tb'] || window.utag.data['qp.tbl'];
+        return teaserBlock || window.utag.data['cp.utag_main_tb'] || window.utag.data['qp.tbl'] || '';
     },
     deleteTrackingValuesFromCookie: function () {
         window.utag.loader.SC('utag_main', { 'hti': '' + ';exp-session' });

--- a/tests/doplugins/doplugins_home_teaser_tracking.test.js
+++ b/tests/doplugins/doplugins_home_teaser_tracking.test.js
@@ -53,17 +53,32 @@ describe('_homeTeaserTrackingObj', () => {
         });
     });
 
+    describe('getBlockValue', () => {
+        it('should return the tb value from utag_main cookie if available', function () {
+            window.utag.data['cp.utag_main_tb'] = 'any-tb-value';
+            const result = s._homeTeaserTrackingObj.getBlockValue();
+            expect(result).toBe(window.utag.data['cp.utag_main_tb']);
+        });
+
+        it('should return the tbl URL query parameter if available', function () {
+            window.utag.data['qp.tbl'] = 'any-dtp-value';
+            const result = s._homeTeaserTrackingObj.getBlockValue();
+            expect(result).toBe(window.utag.data['qp.tbl']);
+        });
+    });
+
     describe('setEvars', () => {
         it('should assign teaser tracking values to certain eVars', function () {
             const anyTrackingValue = 'any-tracking-value';
+            const anyBlockValue = 'any-block-value';
             const anyPageId = '123456';
             window.utag.data.page_id = anyPageId;
-            window.utag.data['cp.utag_main_tb'] = 'any-teaser-block';
             jest.spyOn(s._homeTeaserTrackingObj, 'getTrackingValue').mockImplementation().mockReturnValue(anyTrackingValue);
+            jest.spyOn(s._homeTeaserTrackingObj, 'getBlockValue').mockImplementation().mockReturnValue(anyBlockValue);
             s._homeTeaserTrackingObj.setEvars(s);
             expect(s.eVar66).toBe(anyTrackingValue);
             expect(s.eVar92).toBe(anyTrackingValue + '|' + anyPageId);
-            expect(s.eVar97).toBe(window.utag.data['cp.utag_main_tb']);
+            expect(s.eVar97).toBe(anyBlockValue);
         });
     });
 


### PR DESCRIPTION
Topic : BOOKs Article Teaser at BILD Homepage
If a user click such Teaser we add URL parameter "tbl" to the target URL. 
tbl contains of the Blockname where the teaser was placed ad BILD Home.
Now, our Adobe request should show eVar92 with the value of tbl.