### PR TITLE
setup sportdaten center defaults

### DIFF
--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -598,6 +598,12 @@ s._bildPageNameObj = {
                 || !!window.utag.data.page_sub_type && window.utag.data.page_sub_type === 'LIVETICKER');
     },
 
+    isSport: function () {
+        return !!window.document.domain
+            && (window.document.domain === 'm.sport.bild.de'
+                || window.document.domain === 'sport.bild.de');
+    },
+
     isLiveSport: function () {
         return !!this.isDocTypeArticle()
             && !!window.utag.data.page_cms_path
@@ -629,6 +635,12 @@ s._bildPageNameObj = {
             s.eVar3 = 'live-sport';
             s.prop3 = 'live-sport';
             s.pageName = 'live-sport : ' + window.utag.data['page_id'];
+        } else if (this.isSport()) {
+            window.utag.data.page_mapped_doctype_for_pagename = 'sportdaten';
+            s.eVar3 = 'sportdaten';
+            s.prop3 = 'sportdaten';
+            s.pageName = 'sportdaten : ' + window.utag.data['page_id'];
+            s.eVar4 = window.utag.data['dom.pathname'] == '/' ? window.utag.data['dom.pathname'] + 'home' : window.utag.data['dom.pathname'];
         }
     },
 

--- a/tests/doplugins/doplugins_bild_page_name.test.js
+++ b/tests/doplugins/doplugins_bild_page_name.test.js
@@ -169,17 +169,36 @@ describe('_bildPageNameObj', () => {
         });
     });
 
+    describe('isSport', () => {
+        it('should be false if Domain is not sport', () => {
+            window.document.domain = 'any-sport.bild.de';
+            const returnValue = s._bildPageNameObj.isSport(s);
+            expect(returnValue).toBe(false);
+        });
+
+        it('should be true if Domain is sport.bild.de', () => {
+            window.document.domain = 'sport.bild.de';
+            const returnValue = s._bildPageNameObj.isSport(s);
+            expect(returnValue).toBe(true);
+        });
+
+
+
+    });
+
     describe('setPageName', () => {
         let isHome;
         let isAdWall;
         let isLive;
         let isLiveSport;
+        let isSport;
 
         beforeEach(() => {
             isHome = jest.spyOn(s._bildPageNameObj, 'isHome').mockReturnValue(false);
             isAdWall = jest.spyOn(s._bildPageNameObj, 'isAdWall').mockReturnValue(false);
             isLive = jest.spyOn(s._bildPageNameObj, 'isLive').mockReturnValue(false);
             isLiveSport = jest.spyOn(s._bildPageNameObj, 'isLiveSport').mockReturnValue(false);
+            isSport = jest.spyOn(s._bildPageNameObj, 'isSport').mockReturnValue(false);
         });
 
         afterEach(() => {
@@ -242,6 +261,18 @@ describe('_bildPageNameObj', () => {
             expect(s.eVar3).toBe('live-sport');
             expect(s.prop3).toBe('live-sport');
             expect(s.pageName).toBe('live-sport : ' + window.utag.data.page_id);
+        });
+
+        it('should set relevant data if isSport is true', () => {
+            window.document.domain = 'sport.bild.de';
+            isLiveSport.mockReturnValue(false);
+            isSport.mockReturnValue(true);
+            s._bildPageNameObj.setPageName(s);
+
+            expect(window.utag.data.page_mapped_doctype_for_pagename).toBe('sportdaten');
+            expect(s.eVar3).toBe('sportdaten');
+            expect(s.prop3).toBe('sportdaten');
+            expect(s.pageName).toBe('sportdaten : ' + window.utag.data.page_id);
         });
     });
 });


### PR DESCRIPTION
Sportdatencenter sport.bild.de was moved to LEAN
We have to set specific values for this pages. page_document_type should be set as "sportdaten" in the data layer. 
 