### PR TITLE
new events added

### DIFF
--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -292,8 +292,6 @@ s._articleViewTypeObj = {
         }
     },
 
-    
-
     getExternalType: function (referrer) {
         const referringDomain = s._utils.getDomainFromURLString(referrer);
 

--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -292,11 +292,13 @@ s._articleViewTypeObj = {
         }
     },
 
+    
+
     getExternalType: function (referrer) {
         const referringDomain = s._utils.getDomainFromURLString(referrer);
 
         if (this.isFromSearch(referringDomain)) {
-            return 'event24'; //Search
+            return 'event24,event210'; //Search
         } else if (this.isFromSocial(referrer)) {
             return 'event25'; //Social
         } else if (this.isFromBild(referringDomain) && this.isFromHome(referrer)) {
@@ -422,6 +424,10 @@ s._articleViewTypeObj = {
 s._setExternalReferringDomainEvents = function (s) {
     const domainsToEventMapping = [
         {
+            domains: ['news.google'],
+            event: 'event48',
+        },
+        {
             domains: ['www.google.com', 'www.google.de'],
             event: 'event49',
             matchExact: 'true',
@@ -431,8 +437,17 @@ s._setExternalReferringDomainEvents = function (s) {
             event: 'event49',
         },
         {
-            domains: ['news.google'],
-            event: 'event48',
+            domains: ['googlequicksearchbox'],
+            event: 'event213',
+            matchExact: 'true',
+        },
+        {
+            domains: ['www.google.com/', 'www.google.de/'],
+            event: 'event213',
+        },
+        {
+            domains: ['bing.com', 'ecosia.org', 'duckduckgo.com', 'amp-welt-de.cdn.ampproject.org', 'qwant.com', 'suche.t-online.de', '.yandex.', 'yahoo.com', 'googleapis.com', 'nortonsafe.search.ask.com', 'wikipedia.org', 'googleadservices.com', 'search.myway.com', 'lycos.de'],
+            event: 'event213',
         },
         {
             domains: ['instagram.com'],

--- a/tests/doplugins/doplugins_article_view_type.test.js
+++ b/tests/doplugins/doplugins_article_view_type.test.js
@@ -400,7 +400,7 @@ describe('articleViewType()', () => {
             isFromSearchMock.mockReturnValue(true);
             const result = s._articleViewTypeObj.getExternalType(anyReferrer);
             expect(isFromSearchMock).toHaveBeenCalledWith(anyReferrerDomain);
-            expect(result).toBe('event24');
+            expect(result).toBe('event24,event210');
         });
 
         it('should return event25 if referrer is from social media', function () {

--- a/tests/doplugins/doplugins_externel_referring_domain.test.js
+++ b/tests/doplugins/doplugins_externel_referring_domain.test.js
@@ -26,42 +26,51 @@ describe('External referring domains', () => {
         expect(getReferrerMock).not.toBeCalled();
     });
 
-    it('should set event49 if the referring domain is www.google.com', () => {
+    it('should set event49 and it should not set event213 if the referring domain is www.google.de', () => {
         getReferrerMock.mockReturnValue('www.google.com');
 
         s._setExternalReferringDomainEvents(s);
         expect(addEventMock).toHaveBeenCalledWith('event49');
-
+        expect(addEventMock).not.toHaveBeenCalledWith('event213');
     });
 
-    it('should set event49 if the referring domain is www.google.de', () => {
-        getReferrerMock.mockReturnValue('www.google.com');
-
-        s._setExternalReferringDomainEvents(s);
-        expect(addEventMock).toHaveBeenCalledWith('event49');
-    });
-
-    it('should not set event49 if the referring domain is not www.google.com', () => {
+    it('should set event213 and should not set event49 if the referring domain is www.google.com/', () => {
         getReferrerMock.mockReturnValue('www.google.com/');
 
         s._setExternalReferringDomainEvents(s);
 
         expect(addEventMock).not.toHaveBeenCalledWith('event49');
+        expect(addEventMock).toHaveBeenCalledWith('event213');
     });
 
-    it('should not set event49 if the referring domain is not www.google.de', () => {
-        getReferrerMock.mockReturnValue('www.google.de/');
-
-        s._setExternalReferringDomainEvents(s);
-
-        expect(addEventMock).not.toHaveBeenCalledWith('event49');
-    });
-
-    it('should set event49 if the referring domain includes googlequicksearch/', () => {
+    it('should set event49 and it should not set event213 if the referring domain includes googlequicksearch/', () => {
         getReferrerMock.mockReturnValue('googlequicksearchbox/test');
 
         s._setExternalReferringDomainEvents(s);
         expect(addEventMock).toHaveBeenCalledWith('event49');
+        expect(addEventMock).not.toHaveBeenCalledWith('event213');
+    });
+
+    it('should set event213 and it should not set event49 if the referring domain ends googlequicksearch', () => {
+        getReferrerMock.mockReturnValue('googlequicksearchbox');
+
+        s._setExternalReferringDomainEvents(s);
+        expect(addEventMock).toHaveBeenCalledWith('event213');
+        expect(addEventMock).not.toHaveBeenCalledWith('event49');
+    });
+
+    it('should set event213 if the referring domain is from search engine bing.com', () => {
+        getReferrerMock.mockReturnValue('bing.com');
+
+        s._setExternalReferringDomainEvents(s);
+        expect(addEventMock).toHaveBeenCalledWith('event213');
+    });
+
+    it('should set event213 if the referring domain is from search engine qwant.com', () => {
+        getReferrerMock.mockReturnValue('qwant.com');
+
+        s._setExternalReferringDomainEvents(s);
+        expect(addEventMock).toHaveBeenCalledWith('event213');
     });
 
     it('should set event48 if the referring domain includes news.google', () => {


### PR DESCRIPTION
I added a new event213 for "other search". That means, all Traffic from Search is event24,event210 (old,new event) and can be splitted into event48 (Google News), event49 (Google Search) and event213 (other search). 