### PR TITLE
moved referrer stuff from articleViewType to utils

### DIFF
--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -318,30 +318,8 @@ s._articleViewTypeObj = {
         }
     },
 
-    getReferrerFromLocationHash: function () {
-        let referrerFromHash;
-        if (window.location.hash.indexOf('wt_ref') !== -1) {
-            referrerFromHash = window.location.hash.replace('###wt_ref=', '');
-            referrerFromHash = decodeURIComponent(referrerFromHash);
-        }
-        // exclude Outbrain URL
-        return (this.isValidURL(referrerFromHash) && !referrerFromHash.includes('https://traffic.outbrain.com'))
-            ? referrerFromHash : '';
-    },
-
-    getReferrerFromGetParameter: function () {
-        let referrerFromGetParameter;
-        if (window.utag.data['qp.t_ref']) {
-            referrerFromGetParameter = window.utag.data['qp.t_ref'];
-
-        }
-        // exclude Outbrain URL
-        return (this.isValidURL(referrerFromGetParameter) && !referrerFromGetParameter.includes('https://traffic.outbrain.com'))
-            ? referrerFromGetParameter : '';
-    },
-
     getViewTypeByReferrer: function () {
-        const referrer = this.getReferrerFromLocationHash() || this.getReferrerFromGetParameter() || window.document.referrer ;
+        const referrer = s._utils.getReferrer(); 
         let articleViewType;
 
         if (this.isFromInternal(referrer)) {

--- a/tests/doplugins/doplugins_article_view_type.test.js
+++ b/tests/doplugins/doplugins_article_view_type.test.js
@@ -500,37 +500,20 @@ describe('articleViewType()', () => {
         });
     });
 
-    describe('getReferrerFromLocationHash', () => {
-        const anyValidUrl = 'https://any-valid-url.de';
-
-        it('should return the referrer from the location hash', () => {
-            window.location.hash = `###wt_ref=${anyValidUrl}`;
-            const result = s._articleViewTypeObj.getReferrerFromLocationHash();
-
-            expect(result).toBe(anyValidUrl);
-        });
-
-        it('should ONLY return the referrer if location hash contains a valid URL', () => {
-            const anyInvalidUrl = 'invalid-url';
-            window.location.hash = `###wt_ref=${anyInvalidUrl}`;
-            const result = s._articleViewTypeObj.getReferrerFromLocationHash();
-
-            expect(result).toBe('');
-        });
-    });
-
-    describe('getViewTypeByReferrer()', () => {
+    describe('getViewTypeByReferrer', () => {
         let isFromInternalMock;
         let getInternalTypeMock;
         let getExternalTypeMock;
         let getReferrerFromLocationHashMock;
+        let getReferrerFromGetParameterMock;
 
 
         beforeEach(() => {
             isFromInternalMock = jest.spyOn(s._articleViewTypeObj, 'isFromInternal').mockReturnValue(false);
             getInternalTypeMock = jest.spyOn(s._articleViewTypeObj, 'getInternalType').mockReturnValue(false);
             getExternalTypeMock = jest.spyOn(s._articleViewTypeObj, 'getExternalType').mockReturnValue(false);
-            getReferrerFromLocationHashMock = jest.spyOn(s._articleViewTypeObj, 'getReferrerFromLocationHash').mockReturnValue('');
+            getReferrerFromLocationHashMock = jest.spyOn(s._utils, 'getReferrerFromLocationHash').mockReturnValue('');
+            getReferrerFromGetParameterMock = jest.spyOn(s._utils, 'getReferrerFromGetParameter').mockReturnValue('');
         });
 
         it('should use the URL from the location hash as the referrer if available', () => {
@@ -538,6 +521,13 @@ describe('articleViewType()', () => {
             getReferrerFromLocationHashMock.mockReturnValue(anyReferrerFromHash);
             s._articleViewTypeObj.getViewTypeByReferrer();
             expect(isFromInternalMock).toHaveBeenCalledWith(anyReferrerFromHash);
+        });
+
+        it('should use the URL from GET Parameter as the referrer if available', () => {
+            const anyReferrerFromGET = 'any-referrer-from-get';
+            getReferrerFromGetParameterMock.mockReturnValue(anyReferrerFromGET);
+            s._articleViewTypeObj.getViewTypeByReferrer();
+            expect(isFromInternalMock).toHaveBeenCalledWith(anyReferrerFromGET);
         });
 
         it('should use the document referrer if the location hash is NOT available', () => {

--- a/tests/doplugins/doplugins_utils.test.js
+++ b/tests/doplugins/doplugins_utils.test.js
@@ -147,4 +147,51 @@ describe('s_utils', () => {
             expect(result).toBe(false);
         });
     });
+
+    describe('getReferrerFromLocationHash', () => {
+        let getReferrerFromLocationHashMock;
+
+        beforeEach(() => {
+            getReferrerFromLocationHashMock = jest.spyOn(s._utils, 'getReferrerFromLocationHash').mockReturnValue('');
+        });
+
+        it('should get the hash if the location hash as the referrer if available', () => {
+            const anyReferrerFromHash = 'any-referrer-from-hash';
+            getReferrerFromLocationHashMock.mockReturnValue(anyReferrerFromHash);
+            const result = s._utils.getReferrerFromLocationHash();
+            expect(result).toBe(anyReferrerFromHash);
+        });
+
+    });
+
+    describe('getReferrerFromGetParameter', () => {
+        let getReferrerFromGetParameterMock;
+
+        beforeEach(() => {
+            getReferrerFromGetParameterMock = jest.spyOn(s._utils, 'getReferrerFromGetParameter').mockReturnValue('');
+        });
+
+        it('should get the get Paraneter if the get parameter as the referrer if available', () => {
+            const anyReferrerFromGet = 'any-referrer-from-get';
+            getReferrerFromGetParameterMock.mockReturnValue(anyReferrerFromGet);
+            const result = s._utils.getReferrerFromGetParameter();
+            expect(result).toBe(anyReferrerFromGet);
+        });
+
+    });
+
+    /*describe('getReferrerFromGetParameter', () => {
+        let getReferrerFromGetParameterMock;
+
+        beforeEach(() => {
+            getReferrerFromGetParameterMock = jest.spyOn(s._utils, 'getReferrerFromGetParameter').mockReturnValue('');
+        });
+
+        it('should use the URL from GET Parameter as the referrer if available', () => {
+            const anyReferrerFromGET = 'any-referrer-from-get';
+            getReferrerFromGetParameterMock.mockReturnValue(anyReferrerFromGET);
+            //s._utils.getViewTypeByReferrer();
+            expect(getReferrerFromGetParameterMock).toHaveBeenCalledWith(anyReferrerFromGET);
+        });
+    });*/
 });

--- a/tests/doplugins/doplugins_utils.test.js
+++ b/tests/doplugins/doplugins_utils.test.js
@@ -149,36 +149,41 @@ describe('s_utils', () => {
     });
 
     describe('getReferrerFromLocationHash', () => {
-        let getReferrerFromLocationHashMock;
+        const anyValidUrl = 'https://any-valid-url.de';
 
-        beforeEach(() => {
-            getReferrerFromLocationHashMock = jest.spyOn(s._utils, 'getReferrerFromLocationHash').mockReturnValue('');
-        });
-
-        it('should get the hash if the location hash as the referrer if available', () => {
-            const anyReferrerFromHash = 'any-referrer-from-hash';
-            getReferrerFromLocationHashMock.mockReturnValue(anyReferrerFromHash);
+        it('should return the referrer from the location hash', () => {
+            window.location.hash = `###wt_ref=${anyValidUrl}`;
             const result = s._utils.getReferrerFromLocationHash();
-            expect(result).toBe(anyReferrerFromHash);
+
+            expect(result).toBe(anyValidUrl);
         });
 
+        it('should ONLY return the referrer if location hash contains a valid URL', () => {
+            const anyInvalidUrl = 'invalid-url';
+            window.location.hash = `###wt_ref=${anyInvalidUrl}`;
+            const result = s._utils.getReferrerFromLocationHash();
+
+            expect(result).toBe('');
+        });
     });
 
     describe('getReferrerFromGetParameter', () => {
-        let getReferrerFromGetParameterMock;
+        const anyValidUrl = 'https://any-valid-url.de';
 
-        beforeEach(() => {
-            getReferrerFromGetParameterMock = jest.spyOn(s._utils, 'getReferrerFromGetParameter').mockReturnValue('');
-        });
-
-        it('should get the get Paraneter if the get parameter as the referrer if available', () => {
-            const anyReferrerFromGet = 'any-referrer-from-get';
-            window.location.search = `?t_ref=${anyReferrerFromGet}`;
-            getReferrerFromGetParameterMock.mockReturnValue(anyReferrerFromGet);
+        it('should return the referrer from the get parameter t_ref', () => {
+            window.utag.data['qp.t_ref'] = anyValidUrl;
             const result = s._utils.getReferrerFromGetParameter();
-            expect(result).toBe(anyReferrerFromGet);
+
+            expect(result).toBe(anyValidUrl);
         });
 
+        it('should ONLY return the referrer if the get parameter t_ref exists', () => {
+            const anyInvalidUrl = 'invalid-url';
+            window.location.search = `?t_ref=${anyInvalidUrl}`;
+            const result = s._utils.getReferrerFromGetParameter();
+
+            expect(result).toBe('');
+        });
     });
 
 });

--- a/tests/doplugins/doplugins_utils.test.js
+++ b/tests/doplugins/doplugins_utils.test.js
@@ -173,6 +173,7 @@ describe('s_utils', () => {
 
         it('should get the get Paraneter if the get parameter as the referrer if available', () => {
             const anyReferrerFromGet = 'any-referrer-from-get';
+            window.location.search = `?t_ref=${anyReferrerFromGet}`;
             getReferrerFromGetParameterMock.mockReturnValue(anyReferrerFromGet);
             const result = s._utils.getReferrerFromGetParameter();
             expect(result).toBe(anyReferrerFromGet);
@@ -180,18 +181,4 @@ describe('s_utils', () => {
 
     });
 
-    /*describe('getReferrerFromGetParameter', () => {
-        let getReferrerFromGetParameterMock;
-
-        beforeEach(() => {
-            getReferrerFromGetParameterMock = jest.spyOn(s._utils, 'getReferrerFromGetParameter').mockReturnValue('');
-        });
-
-        it('should use the URL from GET Parameter as the referrer if available', () => {
-            const anyReferrerFromGET = 'any-referrer-from-get';
-            getReferrerFromGetParameterMock.mockReturnValue(anyReferrerFromGET);
-            //s._utils.getViewTypeByReferrer();
-            expect(getReferrerFromGetParameterMock).toHaveBeenCalledWith(anyReferrerFromGET);
-        });
-    });*/
 });


### PR DESCRIPTION
getReferrerFromLocationHash and getReferrerFromGetParameter we have twice in our doPlugin. 
Task was to remove both from articleViewType(), change code that we only use both in utils(). Move unit tests.