### PR TITLE
new events for referrer and campaign added, we now fire old and new s…

### DIFF
--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -400,16 +400,16 @@ s._setExternalReferringDomainEvents = function (s) {
     const domainsToEventMapping = [
         {
             domains: ['news.google'],
-            event: 'event48',
+            event: 'event48,event211',
         },
         {
             domains: ['www.google.com', 'www.google.de'],
-            event: 'event49',
+            event: 'event49,event212',
             matchExact: 'true',
         },
         {
             domains: ['googlequicksearchbox/'],
-            event: 'event49',
+            event: 'event49,event212',
         },
         {
             domains: ['googlequicksearchbox'],
@@ -426,19 +426,19 @@ s._setExternalReferringDomainEvents = function (s) {
         },
         {
             domains: ['instagram.com'],
-            event: 'event53',
+            event: 'event53,event224',
         },
         {
             domains: ['youtube.com'],
-            event: 'event50',
+            event: 'event50,event223',
         },
         {
             domains: ['t.co', 'twitter.com', 'android-app://com.twitter.android'],
-            event: 'event51',
+            event: 'event51,event222',
         },
         {
             domains: ['facebook.com'],
-            event: 'event52',
+            event: 'event52,event221',
         },
         {
             domains: ['telegram.org', 'org.telegram'],
@@ -496,16 +496,16 @@ s._setTrackingValueEvents = function (s) {
                     s._eventsObj.addEvent('event225');
                     break;
                 case isSocialTrackingValue.includes('.instagram.'):
-                    s._eventsObj.addEvent('event53');
+                    s._eventsObj.addEvent('event53,event224');
                     break;
                 case isSocialTrackingValue.includes('.youtube.'):
-                    s._eventsObj.addEvent('event50');
+                    s._eventsObj.addEvent('event50,event223');
                     break;
                 case isSocialTrackingValue.includes('.twitter.'):
-                    s._eventsObj.addEvent('event51');
+                    s._eventsObj.addEvent('event51,event222');
                     break;
                 case isSocialTrackingValue.includes('.facebook.'):
-                    s._eventsObj.addEvent('event52');
+                    s._eventsObj.addEvent('event52,event221');
                     break;
                 case isSocialTrackingValue.includes('.linkedin.'):
                     s._eventsObj.addEvent('event227');

--- a/tests/doplugins/doplugins_externel_referring_domain.test.js
+++ b/tests/doplugins/doplugins_externel_referring_domain.test.js
@@ -30,7 +30,7 @@ describe('External referring domains', () => {
         getReferrerMock.mockReturnValue('www.google.com');
 
         s._setExternalReferringDomainEvents(s);
-        expect(addEventMock).toHaveBeenCalledWith('event49');
+        expect(addEventMock).toHaveBeenCalledWith('event49,event212');
         expect(addEventMock).not.toHaveBeenCalledWith('event213');
     });
 
@@ -39,7 +39,7 @@ describe('External referring domains', () => {
 
         s._setExternalReferringDomainEvents(s);
 
-        expect(addEventMock).not.toHaveBeenCalledWith('event49');
+        expect(addEventMock).not.toHaveBeenCalledWith('event49,event212');
         expect(addEventMock).toHaveBeenCalledWith('event213');
     });
 
@@ -47,7 +47,7 @@ describe('External referring domains', () => {
         getReferrerMock.mockReturnValue('googlequicksearchbox/test');
 
         s._setExternalReferringDomainEvents(s);
-        expect(addEventMock).toHaveBeenCalledWith('event49');
+        expect(addEventMock).toHaveBeenCalledWith('event49,event212');
         expect(addEventMock).not.toHaveBeenCalledWith('event213');
     });
 
@@ -77,49 +77,49 @@ describe('External referring domains', () => {
         getReferrerMock.mockReturnValue('news.google/');
 
         s._setExternalReferringDomainEvents(s);
-        expect(addEventMock).toHaveBeenCalledWith('event48');
+        expect(addEventMock).toHaveBeenCalledWith('event48,event211');
     });
 
     it('should set event53 if the referring domain includes instagram.com', () => {
         getReferrerMock.mockReturnValue('instagram.com/');
 
         s._setExternalReferringDomainEvents(s);
-        expect(addEventMock).toHaveBeenCalledWith('event53');
+        expect(addEventMock).toHaveBeenCalledWith('event53,event224');
     });
 
     it('should set event50 if the referring domain includes youtube.com', () => {
         getReferrerMock.mockReturnValue('youtube.com/');
 
         s._setExternalReferringDomainEvents(s);
-        expect(addEventMock).toHaveBeenCalledWith('event50');
+        expect(addEventMock).toHaveBeenCalledWith('event50,event223');
     });
 
     it('should set event51 if the referring domain includes twitter.com', () => {
         getReferrerMock.mockReturnValue('twitter.com/');
 
         s._setExternalReferringDomainEvents(s);
-        expect(addEventMock).toHaveBeenCalledWith('event51');
+        expect(addEventMock).toHaveBeenCalledWith('event51,event222');
     });
 
     it('should set event51 if the referring domain includes android-app://com.twitter.android', () => {
         getReferrerMock.mockReturnValue('android-app://com.twitter.android/');
 
         s._setExternalReferringDomainEvents(s);
-        expect(addEventMock).toHaveBeenCalledWith('event51');
+        expect(addEventMock).toHaveBeenCalledWith('event51,event222');
     });
 
     it('should set event51 if the referring domain includes t.co', () => {
         getReferrerMock.mockReturnValue('t.co/');
 
         s._setExternalReferringDomainEvents(s);
-        expect(addEventMock).toHaveBeenCalledWith('event51');
+        expect(addEventMock).toHaveBeenCalledWith('event51,event222');
     });
 
     it('should set event52 if the referring domain includes facebook.com', () => {
         getReferrerMock.mockReturnValue('facebook.com/');
 
         s._setExternalReferringDomainEvents(s);
-        expect(addEventMock).toHaveBeenCalledWith('event52');
+        expect(addEventMock).toHaveBeenCalledWith('event52,event221');
     });
 
     it('should set event225 if the referring domain includes telegram.org', () => {

--- a/tests/doplugins/doplugins_trackingValue_events.test.js
+++ b/tests/doplugins/doplugins_trackingValue_events.test.js
@@ -98,14 +98,14 @@ describe('_setTrackingValueEvents (URL Parameter like cid)', () => {
         isSocialTrackingParameterMock.mockReturnValue(true);
 
         s._setTrackingValueEvents(s);
-        expect(addEventMock).toHaveBeenCalledWith('event53');
+        expect(addEventMock).toHaveBeenCalledWith('event53,event224');
     });
     it('should not set event53 if the trackingValue does not contain .instagram.', () => {
         getTrackingValueMock.mockReturnValue('any-trackingValue');
         isSocialTrackingParameterMock.mockReturnValue(true);
 
         s._setTrackingValueEvents(s);
-        expect(addEventMock).not.toHaveBeenCalledWith('event53');
+        expect(addEventMock).not.toHaveBeenCalledWith('event53,event224');
     });   
 
     //Youtube
@@ -114,14 +114,14 @@ describe('_setTrackingValueEvents (URL Parameter like cid)', () => {
         isSocialTrackingParameterMock.mockReturnValue(true);
 
         s._setTrackingValueEvents(s);
-        expect(addEventMock).toHaveBeenCalledWith('event50');
+        expect(addEventMock).toHaveBeenCalledWith('event50,event223');
     });
     it('should not set event50 if the trackingValue does not contain .youtube.', () => {
         getTrackingValueMock.mockReturnValue('any-trackingValue');
         isSocialTrackingParameterMock.mockReturnValue(true);
 
         s._setTrackingValueEvents(s);
-        expect(addEventMock).not.toHaveBeenCalledWith('event50');
+        expect(addEventMock).not.toHaveBeenCalledWith('event50,event223');
     });     
  
     //Twitter
@@ -130,14 +130,14 @@ describe('_setTrackingValueEvents (URL Parameter like cid)', () => {
         isSocialTrackingParameterMock.mockReturnValue(true);
 
         s._setTrackingValueEvents(s);
-        expect(addEventMock).toHaveBeenCalledWith('event51');
+        expect(addEventMock).toHaveBeenCalledWith('event51,event222');
     });
     it('should not set event50 if the trackingValue does not contain .twitter.', () => {
         getTrackingValueMock.mockReturnValue('any-trackingValue');
         isSocialTrackingParameterMock.mockReturnValue(true);
 
         s._setTrackingValueEvents(s);
-        expect(addEventMock).not.toHaveBeenCalledWith('event51');
+        expect(addEventMock).not.toHaveBeenCalledWith('event51,event222');
     });         
     //Facebook
     it('should set event52 if the trackingValue contains .facebook.', () => {
@@ -145,7 +145,7 @@ describe('_setTrackingValueEvents (URL Parameter like cid)', () => {
         isSocialTrackingParameterMock.mockReturnValue(true);
 
         s._setTrackingValueEvents(s);
-        expect(addEventMock).toHaveBeenCalledWith('event52');
+        expect(addEventMock).toHaveBeenCalledWith('event52,event221');
     });
     it('should not set event52 if the trackingValue does not contain .facebook.', () => {
         getTrackingValueMock.mockReturnValue('any-trackingValue');


### PR DESCRIPTION
…etup
Ticketnumber is wrong, its related to TRAC-1691
I added the new event structure to campaign and referrer split events (like twitter, insta, google news).
Old events are still there, only mapping is extended. No change in logic