### PR TITLE
exclude fromHome events when user click at Lesen Sie auch

### DIFF
--- a/extensions/doPlugins_global.js
+++ b/extensions/doPlugins_global.js
@@ -339,6 +339,10 @@ s._articleViewTypeObj = {
         return (s._ppvPreviousPage || '').includes('search :');
     },
 
+    isFromLesenSieAuch: function() {
+        return (window.utag.data['cp.utag_main_lsa'].includes('1'));
+    },
+
     getInternalType: function (referrer) {
         let pageViewEvent;
         let channel;
@@ -348,7 +352,7 @@ s._articleViewTypeObj = {
             return {pageViewEvent};
         }
 
-        if (this.isFromHome(referrer) && this.isNavigated() && !this.isSelfRedirect() && !this.isFromOnsiteSearch()) {
+        if (this.isFromHome(referrer) && this.isNavigated() && !this.isSelfRedirect() && !this.isFromOnsiteSearch() && !this.isFromLesenSieAuch()) {
             pageViewEvent = 'event22,event200'; //Home
         } else {
             pageViewEvent = 'event23,event201'; //Other Internal

--- a/tests/doplugins/doplugins_article_view_type.test.js
+++ b/tests/doplugins/doplugins_article_view_type.test.js
@@ -488,12 +488,33 @@ describe('articleViewType()', () => {
         });
     });
 
+    describe('isFromLesenSieAuch', () => {
+        
+        it('should return TRUE if page was loaded via "LESEN SIE AUCH" that is shown in cookie utag_main_lsa)', function () {
+            
+            window.utag.data['cp.utag_main_lsa'] = '1';
+            
+            const result = s._articleViewTypeObj.isFromLesenSieAuch();
+            expect(result).toBe(true);
+        });
+
+        it('should return FALSE if page was NOT loaded via "LESEN SIE AUCH" that is shown in cookie utag_main_lsa)', function () {
+            
+            window.utag.data['cp.utag_main_lsa'] = 'any_value';
+            
+            const result = s._articleViewTypeObj.isFromLesenSieAuch();
+            expect(result).toBe(false);
+        });
+
+    });
+
     describe('getInternalType()', () => {
         let isFromHomeMock;
         let isSamePageRedirectMock;
         let isNavigatedMock;
         let isSelfRedirectMock;
         let isFromOnsiteSearchMock;
+        let isFromLesenSieAuchMock;
 
         beforeEach(() => {
             isFromHomeMock = jest.spyOn(s._articleViewTypeObj, 'isFromHome').mockReturnValue(false);
@@ -501,6 +522,7 @@ describe('articleViewType()', () => {
             isNavigatedMock = jest.spyOn(s._articleViewTypeObj, 'isNavigated').mockReturnValue(false);
             isSelfRedirectMock = jest.spyOn(s._articleViewTypeObj, 'isSelfRedirect').mockReturnValue(false);
             isFromOnsiteSearchMock = jest.spyOn(s._articleViewTypeObj, 'isFromOnsiteSearch').mockReturnValue(false);
+            isFromLesenSieAuchMock = jest.spyOn(s._articleViewTypeObj, 'isFromLesenSieAuch').mockReturnValue(false);
         });
 
         it('should return event22 if referrer is a home page and page was navigated and it was no selfRedirect and not via OnsiteSearch', function () {
@@ -508,6 +530,8 @@ describe('articleViewType()', () => {
             isFromHomeMock.mockReturnValue(true);
             isNavigatedMock.mockReturnValue(true);
             isSelfRedirectMock.mockReturnValue(false);
+            isFromOnsiteSearchMock.mockReturnValue(false);
+            isFromLesenSieAuchMock.mockReturnValue(false);
             const result = s._articleViewTypeObj.getInternalType('http://www.any-domain.de');
             expect(isFromHomeMock).toHaveBeenCalledWith(anyReferrer);
             expect(result.pageViewEvent).toBe('event22,event200','Home');


### PR DESCRIPTION
PR is because mobile user are recognized as click from home when they click at "lesen Sie auch" in BILD articles. 