### PR TITLE
Latest Status is that we now use Sourcepoints onConsentReady

### DIFF
--- a/extensions/cmp/cmp_interaction_tracking.js
+++ b/extensions/cmp/cmp_interaction_tracking.js
@@ -209,8 +209,8 @@
     }
 
     function onConsentReady(messageType) {
-            window.utag.data['cmp_onConsentReady'] = messageType.eventStatus;
-            }
+        window.utag.data['cmp_onConsentReady'] = messageType.eventStatus;
+    }
 
     function onMessage(event) {
         if (event.data && event.data.cmpLayerMessage) {

--- a/extensions/cmp/cmp_interaction_tracking.js
+++ b/extensions/cmp/cmp_interaction_tracking.js
@@ -65,7 +65,8 @@
         onUserConsent,
         sendFirstPageViewEvent,
         hasUserDeclinedConsent,
-        isAfterCMP
+        isAfterCMP,
+        onConsentReady
     };
 
     function getABTestingProperties() {
@@ -207,6 +208,10 @@
         }
     }
 
+    function onConsentReady(messageType) {
+            window.utag.data['cmp_onConsentReady'] = messageType.eventStatus;
+            }
+
     function onMessage(event) {
         if (event.data && event.data.cmpLayerMessage) {
             exportedFunctions.sendLinkEvent(event.data.payload);
@@ -235,6 +240,9 @@
         window._sp_queue.push(() => {
             window.__tcfapi('addEventListener', 2, onCmpuishown);
         });
+        window._sp_queue.push(() => {
+            window.__tcfapi('addEventListener', 2, onConsentReady);
+        });          
         window.addEventListener('message', onMessage, false);
     }
 

--- a/tests/cmp/cmp_interaction_tracking.test.js
+++ b/tests/cmp/cmp_interaction_tracking.test.js
@@ -148,6 +148,7 @@ describe('CMP Interaction Tracking', () => {
                 expect.any(Function),
                 expect.any(Function),
                 expect.any(Function),
+                expect.any(Function),
                 expect.any(Function)
             ]);
         });
@@ -159,12 +160,13 @@ describe('CMP Interaction Tracking', () => {
             });
 
             expect(window._sp_.addEventListener).toBeCalledTimes(3);
-            expect(window.__tcfapi).toBeCalledTimes(1);
+            expect(window.__tcfapi).toBeCalledTimes(2);
             expect(window._sp_.addEventListener).toHaveBeenCalledWith('onMessageReceiveData', cmpInteractionTracking.onMessageReceiveData);
             expect(window._sp_.addEventListener).toHaveBeenCalledWith('onMessageChoiceSelect', cmpInteractionTracking.onMessageChoiceSelect);
             expect(window._sp_.addEventListener).toHaveBeenCalledWith('onPrivacyManagerAction', cmpInteractionTracking.onPrivacyManagerAction);
             expect(window.__tcfapi).toHaveBeenCalledWith('addEventListener', 2, cmpInteractionTracking.onCmpuishown);
             expect(window.addEventListener).toHaveBeenCalledWith('message', cmpInteractionTracking.onMessage, false);
+            expect(window.__tcfapi).toHaveBeenCalledWith('addEventListener', 2, cmpInteractionTracking.onConsentReady);
         });
     });
 


### PR DESCRIPTION
In messageType we can see if there is an tcString and eventStatus shows

-> “tcloaded” when Consent is already given and no CMP Layer is shown (regular Page View)

-> “cmpuishown” when CMP Layer appears (First Page View)